### PR TITLE
Add prompt type switcher feature

### DIFF
--- a/src/Calendary.Ng/src/app/components/prompt-settings/prompt-settings.component.html
+++ b/src/Calendary.Ng/src/app/components/prompt-settings/prompt-settings.component.html
@@ -1,0 +1,20 @@
+<section class="prompt-settings" [formGroup]="promptForm">
+  <h2>Налаштування промптів</h2>
+  <div class="form-group">
+    <div class="toggle-container">
+      <label for="useImprovedPrompt">Використовувати покращені промпти</label>
+      <mat-slide-toggle
+        formControlName="useImprovedPrompt"
+        color="primary"
+        (change)="onToggleChange()"
+        [disabled]="isLoading">
+      </mat-slide-toggle>
+    </div>
+    <p class="description">
+      Коли активовано, система використовуватиме AI-покращені промпти для кращих результатів генерації зображень.
+    </p>
+    <div *ngIf="saveMessage" class="save-message" [class.success]="saveMessage.includes('збережено')">
+      {{ saveMessage }}
+    </div>
+  </div>
+</section>

--- a/src/Calendary.Ng/src/app/components/prompt-settings/prompt-settings.component.scss
+++ b/src/Calendary.Ng/src/app/components/prompt-settings/prompt-settings.component.scss
@@ -1,0 +1,57 @@
+.prompt-settings {
+  margin-top: 20px;
+  padding: 20px;
+  background-color: #f5f5f5;
+  border-radius: 8px;
+
+  h2 {
+    margin-top: 0;
+    margin-bottom: 20px;
+    font-size: 1.5rem;
+    color: #333;
+  }
+
+  .form-group {
+    margin-bottom: 15px;
+
+    .toggle-container {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 10px 0;
+
+      label {
+        font-size: 1rem;
+        font-weight: 500;
+        color: #555;
+        margin: 0;
+      }
+
+      mat-slide-toggle {
+        margin-left: 20px;
+      }
+    }
+
+    .description {
+      margin-top: 8px;
+      margin-bottom: 0;
+      font-size: 0.875rem;
+      color: #777;
+      line-height: 1.4;
+    }
+
+    .save-message {
+      margin-top: 10px;
+      padding: 8px 12px;
+      border-radius: 4px;
+      font-size: 0.875rem;
+      background-color: #ffebee;
+      color: #c62828;
+
+      &.success {
+        background-color: #e8f5e9;
+        color: #2e7d32;
+      }
+    }
+  }
+}

--- a/src/Calendary.Ng/src/app/components/prompt-settings/prompt-settings.component.ts
+++ b/src/Calendary.Ng/src/app/components/prompt-settings/prompt-settings.component.ts
@@ -1,0 +1,67 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, FormsModule, ReactiveFormsModule } from '@angular/forms';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { SettingService } from '../../../services/setting.service';
+import { Setting } from '../../../models/setting';
+
+@Component({
+  standalone: true,
+  selector: 'app-prompt-settings',
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, MatSlideToggleModule],
+  templateUrl: './prompt-settings.component.html',
+  styleUrl: './prompt-settings.component.scss'
+})
+export class PromptSettingsComponent implements OnInit {
+  promptForm: FormGroup;
+  isLoading = false;
+  saveMessage = '';
+
+  constructor(
+    private fb: FormBuilder,
+    private settingService: SettingService
+  ) {
+    this.promptForm = this.fb.group({
+      useImprovedPrompt: [false]
+    });
+  }
+
+  ngOnInit(): void {
+    this.loadSettings();
+  }
+
+  loadSettings(): void {
+    this.isLoading = true;
+    this.settingService.getSettings().subscribe({
+      next: (settings: Setting) => {
+        this.promptForm.patchValue({
+          useImprovedPrompt: settings.useImprovedPrompt || false
+        });
+        this.isLoading = false;
+      },
+      error: (error) => {
+        console.error('Помилка завантаження налаштувань:', error);
+        this.isLoading = false;
+      }
+    });
+  }
+
+  onToggleChange(): void {
+    const settings = new Setting();
+    settings.useImprovedPrompt = this.promptForm.value.useImprovedPrompt;
+
+    this.saveMessage = '';
+    this.settingService.saveSettings(settings).subscribe({
+      next: () => {
+        this.saveMessage = 'Налаштування збережено';
+        setTimeout(() => {
+          this.saveMessage = '';
+        }, 3000);
+      },
+      error: (error) => {
+        console.error('Помилка збереження налаштувань:', error);
+        this.saveMessage = 'Помилка збереження налаштувань';
+      }
+    });
+  }
+}

--- a/src/Calendary.Ng/src/app/pages/editor/components/generate-modal/generate-modal.component.html
+++ b/src/Calendary.Ng/src/app/pages/editor/components/generate-modal/generate-modal.component.html
@@ -5,6 +5,10 @@
       <div>
         <h2 mat-dialog-title>Генерація зображень</h2>
         <p class="model-name">Модель: {{ data.fluxModelName }}</p>
+        <p class="prompt-mode-indicator" *ngIf="useImprovedPrompt">
+          <mat-icon class="indicator-icon">star</mat-icon>
+          Покращені промпти активовані
+        </p>
       </div>
     </div>
     <button mat-icon-button (click)="onCancel()" [disabled]="isGenerating">

--- a/src/Calendary.Ng/src/app/pages/editor/components/generate-modal/generate-modal.component.scss
+++ b/src/Calendary.Ng/src/app/pages/editor/components/generate-modal/generate-modal.component.scss
@@ -1,7 +1,7 @@
 .generate-modal{min-width:600px;max-width:800px;@media(max-width:900px){min-width:auto;width:100%;max-width:100%}}
 .modal-header{display:flex;justify-content:space-between;align-items:flex-start;padding:24px 24px 16px;border-bottom:1px solid #e5e7eb;
 .header-content{display:flex;gap:16px;align-items:flex-start;mat-icon{font-size:32px;width:32px;height:32px;color:#4058ff}
-h2{margin:0;font-size:20px;font-weight:600;color:#1f2937}.model-name{margin:4px 0 0;font-size:14px;color:#6b7280}}}
+h2{margin:0;font-size:20px;font-weight:600;color:#1f2937}.model-name{margin:4px 0 0;font-size:14px;color:#6b7280}.prompt-mode-indicator{margin:4px 0 0;font-size:13px;color:#10b981;display:flex;align-items:center;gap:4px;font-weight:500;.indicator-icon{font-size:16px;width:16px;height:16px}}}}
 mat-dialog-content{padding:24px;max-height:600px;overflow-y:auto}
 .loading-state{display:flex;flex-direction:column;align-items:center;gap:16px;padding:48px 24px;p{color:#6b7280;margin:0}}
 .form-section{display:flex;flex-direction:column;gap:24px}

--- a/src/Calendary.Ng/src/app/pages/editor/components/generate-modal/generate-modal.component.ts
+++ b/src/Calendary.Ng/src/app/pages/editor/components/generate-modal/generate-modal.component.ts
@@ -17,6 +17,7 @@ import { PromptTheme } from '../../../../../models/prompt-theme';
 import { PromptThemeService } from '../../../../../services/prompt-theme.service';
 import { JobService } from '../../../../../services/job.service';
 import { Job } from '../../../../../models/job';
+import { SettingService } from '../../../../../services/setting.service';
 
 export interface GenerateModalData {
   fluxModelId: number;
@@ -55,6 +56,7 @@ export class GenerateModalComponent implements OnInit {
   promptThemes: PromptTheme[] = [];
   generationMode: GenerationMode = 'theme';
   showAdvancedOptions = false;
+  useImprovedPrompt = false;
 
   // Image dimension presets
   imageSizePresets = [
@@ -69,6 +71,7 @@ export class GenerateModalComponent implements OnInit {
     private fb: FormBuilder,
     private promptThemeService: PromptThemeService,
     private jobService: JobService,
+    private settingService: SettingService,
     private dialogRef: MatDialogRef<GenerateModalComponent>,
     @Inject(MAT_DIALOG_DATA) public data: GenerateModalData
   ) {
@@ -100,7 +103,21 @@ export class GenerateModalComponent implements OnInit {
 
   ngOnInit(): void {
     this.loadPromptThemes();
+    this.loadUserSettings();
     this.updateValidators(this.generationMode);
+  }
+
+  loadUserSettings(): void {
+    this.settingService.getSettings().subscribe({
+      next: (settings) => {
+        this.useImprovedPrompt = settings.useImprovedPrompt || false;
+      },
+      error: (err) => {
+        console.error('Помилка завантаження налаштувань користувача:', err);
+        // Default to false if settings can't be loaded
+        this.useImprovedPrompt = false;
+      }
+    });
   }
 
   loadPromptThemes(): void {

--- a/src/Calendary.Ng/src/app/pages/profile/profile.component.html
+++ b/src/Calendary.Ng/src/app/pages/profile/profile.component.html
@@ -4,10 +4,14 @@
       <h2>Мої замовлення</h2>
       <app-profile-orders></app-profile-orders>
     </section>
-  
+
     <section class="delivery">
       <h2>Налаштування</h2>
       <app-settings></app-settings>
+    </section>
+
+    <section class="prompt-preferences">
+      <app-prompt-settings></app-prompt-settings>
     </section>
 
     <app-change-password></app-change-password>

--- a/src/Calendary.Ng/src/app/pages/profile/profile.component.ts
+++ b/src/Calendary.Ng/src/app/pages/profile/profile.component.ts
@@ -3,11 +3,12 @@ import { SettingService } from '../../../services/setting.service';
 import { SettingsComponent } from '../../components/settings/settings.component';
 import { ProfileOrdersComponent } from '../../components/profile-orders/profile-orders.component';
 import { ChangePasswordComponent } from '../../components/change-password/change-password.component';
+import { PromptSettingsComponent } from '../../components/prompt-settings/prompt-settings.component';
 
 @Component({
     standalone: true,
     selector: 'app-profile',
-    imports: [SettingsComponent, ProfileOrdersComponent, ChangePasswordComponent],
+    imports: [SettingsComponent, ProfileOrdersComponent, ChangePasswordComponent, PromptSettingsComponent],
     templateUrl: './profile.component.html',
     styleUrl: './profile.component.scss'
 })

--- a/src/Calendary.Ng/src/models/setting.ts
+++ b/src/Calendary.Ng/src/models/setting.ts
@@ -2,9 +2,10 @@ import { Country } from "./country";
 import { DayOfWeek } from "./day-of-week.enum";
 import { Language } from "./language";
 
-export class Setting 
+export class Setting
 {
     firstDayOfWeek: DayOfWeek = DayOfWeek.Monday;
     language?: Language;
     country?: Country;
+    useImprovedPrompt: boolean = false;
 }


### PR DESCRIPTION
Implemented Task 12: Allow users to toggle between standard and improved prompts.

Changes:
- Extended Setting model with useImprovedPrompt boolean field
- Created PromptSettingsComponent with Material slide toggle UI
- Integrated prompt settings into user profile page
- Updated GenerateModalComponent to load and display user's prompt preference
- Added visual indicator in generation modal showing improved prompts status

The toggle allows users to enable AI-enhanced prompts for better image generation results.