### PR TITLE
Fix: Docker configuration compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Вибираємо офіційний образ .NET для запуску додатку
 FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS base
 WORKDIR /app
-EXPOSE 80
+EXPOSE 8080
 
 
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   calendary_db:
     container_name: calendary_db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   calendary_db:
     container_name: calendary_db


### PR DESCRIPTION
## Summary
Fix Docker configuration issues that prevent proper build and deployment.

## Problems Fixed
1. **Obsolete version field**: Removed `version: '3'` from docker-compose files (deprecated in Docker Compose v2)
2. **Port mismatch**: Updated Dockerfile to expose port 8080 instead of 80 to match docker-compose configuration
3. **Improved compatibility**: Ensures proper alignment between Dockerfile and docker-compose for .NET 9.0

## Changes
### Dockerfile
```diff
- EXPOSE 80
+ EXPOSE 8080
```

### docker-compose.yml
```diff
- version: '3'
  services:
```

### docker-compose.local.yml
```diff
- version: '3'
  services:
```

## Why These Changes?
- **Version field**: Docker Compose v2 no longer uses the version field, causing warnings
- **Port alignment**: .NET 9.0 defaults to port 8080 in containers, and docker-compose was configured for 8080
- The mismatch between Dockerfile (80) and docker-compose (8080) could cause connection issues

## Testing
- [x] `docker-compose config` runs without warnings
- [x] Dockerfile builds successfully
- [ ] Container starts and listens on correct port
- [ ] API is accessible through mapped port

## Before
```
warning: the attribute `version` is obsolete
Port mismatch: Dockerfile exposes 80, docker-compose maps to 8080
```

## After
```
No warnings from docker-compose config
Port configuration aligned: both use 8080
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)