### PR TITLE
Add Karma config to stabilize Angular tests in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
         run: npm run build -- --configuration production
 
       - name: Run tests
-        run: npm run test -- --watch=false --browsers=ChromeHeadless --code-coverage
+        run: npm run test -- --watch=false --browsers=ChromeHeadlessCI --code-coverage
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         run: npm run build -- --configuration production
 
       - name: Run tests with coverage
-        run: npm run test -- --watch=false --browsers=ChromeHeadless --code-coverage
+        run: npm run test -- --watch=false --browsers=ChromeHeadlessCI --code-coverage
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4

--- a/src/Calendary.Ng/karma.conf.js
+++ b/src/Calendary.Ng/karma.conf.js
@@ -1,0 +1,46 @@
+const { join } = require('path');
+
+module.exports = function (config) {
+  const isCI = process.env.CI === 'true';
+
+  config.set({
+    basePath: '',
+    frameworks: ['jasmine', '@angular-devkit/build-angular'],
+    plugins: [
+      require('karma-jasmine'),
+      require('karma-chrome-launcher'),
+      require('karma-jasmine-html-reporter'),
+      require('karma-coverage')
+    ],
+    client: {
+      jasmine: {},
+      clearContext: false
+    },
+    jasmineHtmlReporter: {
+      suppressAll: true
+    },
+    coverageReporter: {
+      dir: join(__dirname, './coverage'),
+      subdir: '.',
+      reporters: [
+        { type: 'html' },
+        { type: 'lcovonly' },
+        { type: 'text-summary' }
+      ]
+    },
+    reporters: ['progress', 'kjhtml'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    autoWatch: false,
+    browsers: [isCI ? 'ChromeHeadlessCI' : 'ChromeHeadless'],
+    singleRun: false,
+    restartOnFileChange: true,
+    customLaunchers: {
+      ChromeHeadlessCI: {
+        base: 'ChromeHeadless',
+        flags: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage']
+      }
+    }
+  });
+};

--- a/src/Calendary.Ng/package.json
+++ b/src/Calendary.Ng/package.json
@@ -7,7 +7,7 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test",
+    "test": "ng test --browsers=ChromeHeadlessCI",
     "serve:ssr:Calendary.Ng": "node dist/calendary.ng/server/server.mjs"
   },
   "private": true,


### PR DESCRIPTION
## Summary
- add a Karma configuration file for the Angular app with a CI-friendly ChromeHeadless launcher
- point the npm test script and the build/test workflows to the new launcher so the GitHub Actions jobs can execute Angular unit tests with coverage

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadlessCI --code-coverage` *(fails in container: `ng` command not found because Angular dependencies/CLI are not installed here)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919b8604188832bb88ae85f0921f9e9)