### PR TITLE
Add load testing suite for task 31

### DIFF
--- a/backlog/task_31.md
+++ b/backlog/task_31.md
@@ -1,7 +1,7 @@
 # Task 31: Навантажувальне тестування
 
 **Epic**: Future (Backlog) - moved from [Epic 01](../epic_01.md)
-**Статус**: BACKLOG
+**Статус**: DONE
 **Пріоритет**: P3 (Низький - для наступних епіків)
 **Складність**: Висока
 **Час**: 4-6 годин
@@ -42,6 +42,12 @@
 
 - `tests/load/k6-script.js`
 - `tests/load/scenarios.yml`
+
+## Результат виконання
+
+- ✅ Додано `tests/load/k6-script.js` з п'ятьма окремими k6-сценаріями (image, pdf, editor, spike, soak) та збиранням метрик `response_time_ms`, `error_rate`, `request_throughput`.
+- ✅ Створено `tests/load/scenarios.yml` з інструкціями запуску, шаблоном команд для різних середовищ та описом метрик/acceptance criteria.
+- ✅ Порогові значення p95 < 3s та error rate <1% тепер зафіксовані в k6 thresholds, а файл сценаріїв описує моніторинг CPU/memory/DB.
 
 ## Приклад k6 script
 

--- a/tests/load/k6-script.js
+++ b/tests/load/k6-script.js
@@ -1,0 +1,134 @@
+import http from 'k6/http';
+import { check, group, sleep } from 'k6';
+import { Trend, Rate, Counter } from 'k6/metrics';
+
+const API_BASE_URL = __ENV.API_BASE_URL || 'http://localhost:5000';
+const EDITOR_URL = __ENV.EDITOR_URL || 'http://localhost:4200/editor';
+const MODEL_VERSION = __ENV.MODEL_VERSION || 'flux-pro-v1.1';
+const IMAGE_PROMPT = __ENV.IMAGE_PROMPT || 'Ukrainian winter village, cinematic lighting, calendar art';
+const CALENDAR_ID = __ENV.CALENDAR_ID || 1;
+const AUTH_TOKEN = __ENV.API_TOKEN ? `Bearer ${__ENV.API_TOKEN}` : null;
+const DEFAULT_SLEEP = Number(__ENV.SLEEP_SECONDS || 1);
+
+const headers = {
+  'Content-Type': 'application/json',
+  ...(AUTH_TOKEN ? { Authorization: AUTH_TOKEN } : {}),
+};
+
+export const responseTime = new Trend('response_time_ms');
+export const errorRate = new Rate('error_rate');
+export const throughput = new Counter('request_throughput');
+
+export const options = {
+  thresholds: {
+    http_req_duration: ['p(95)<3000'],
+    error_rate: ['rate<0.01'],
+  },
+  scenarios: {
+    image_generation: {
+      executor: 'constant-vus',
+      vus: 10,
+      duration: '3m',
+      exec: 'imageGenerationScenario',
+    },
+    pdf_generation: {
+      executor: 'constant-vus',
+      vus: 5,
+      duration: '3m',
+      exec: 'pdfGenerationScenario',
+    },
+    editor_concurrency: {
+      executor: 'constant-vus',
+      vus: 100,
+      duration: '2m',
+      exec: 'editorScenario',
+    },
+    spike_test: {
+      executor: 'ramping-arrival-rate',
+      exec: 'spikeScenario',
+      startRate: 0,
+      timeUnit: '1s',
+      preAllocatedVUs: 50,
+      maxVUs: 150,
+      stages: [
+        { target: 20, duration: '30s' },
+        { target: 100, duration: '1m' },
+        { target: 0, duration: '30s' },
+      ],
+    },
+    soak_test: {
+      executor: 'constant-vus',
+      vus: 20,
+      duration: '60m',
+      exec: 'soakScenario',
+      gracefulStop: '2m',
+    },
+  },
+};
+
+function trackResult(res, label) {
+  responseTime.add(res.timings.duration, { label });
+  throughput.add(1, { label });
+  const ok = check(res, {
+    [`${label} status is 2xx`]: (r) => r.status >= 200 && r.status < 300,
+    [`${label} duration < 3s`]: (r) => r.timings.duration < 3000,
+  });
+  if (!ok) {
+    errorRate.add(1, { label });
+  }
+}
+
+export function imageGenerationScenario() {
+  group('image-generation', () => {
+    const payload = JSON.stringify({
+      prompt: IMAGE_PROMPT,
+      seed: Math.floor(Math.random() * 100000),
+      modelVersion: MODEL_VERSION,
+    });
+
+    const res = http.post(`${API_BASE_URL}/api/synthesis/generate`, payload, {
+      headers,
+    });
+    trackResult(res, 'image');
+    sleep(DEFAULT_SLEEP);
+  });
+}
+
+export function pdfGenerationScenario() {
+  group('pdf-generation', () => {
+    const res = http.get(`${API_BASE_URL}/api/calendar/generate/${CALENDAR_ID}`, {
+      headers: AUTH_TOKEN ? { Authorization: AUTH_TOKEN } : undefined,
+    });
+    trackResult(res, 'pdf');
+    sleep(DEFAULT_SLEEP);
+  });
+}
+
+export function editorScenario() {
+  group('editor-page', () => {
+    const res = http.get(EDITOR_URL);
+    trackResult(res, 'editor');
+    sleep(DEFAULT_SLEEP);
+  });
+}
+
+export function spikeScenario() {
+  // Spike test hits image generation endpoint because it is the most CPU intensive
+  const payload = JSON.stringify({
+    prompt: `${IMAGE_PROMPT} :: spike`,
+    seed: Math.floor(Math.random() * 1000000),
+    modelVersion: MODEL_VERSION,
+  });
+  const res = http.post(`${API_BASE_URL}/api/synthesis/generate`, payload, {
+    headers,
+  });
+  trackResult(res, 'spike');
+  sleep(0.5);
+}
+
+export function soakScenario() {
+  // Soak test keeps the editor open for a prolonged time
+  const res = http.get(EDITOR_URL);
+  trackResult(res, 'soak');
+  sleep(DEFAULT_SLEEP);
+}

--- a/tests/load/scenarios.yml
+++ b/tests/load/scenarios.yml
@@ -1,0 +1,91 @@
+version: 1
+name: calendary-load-suite
+description: |
+  Узгоджений набір сценаріїв для навантажувального тестування Calendary.
+  Сценарії покривають API генерації зображень, генерацію PDF, навантаження на редактор,
+  spike та soak тести. Запускаються через k6 (tests/load/k6-script.js) з різними
+  наборами environment variables.
+
+tooling:
+  runner: k6
+  commandTemplate: >
+    API_BASE_URL={{ apiBaseUrl }} EDITOR_URL={{ editorUrl }} API_TOKEN={{ apiToken | default('') }} \
+    CALENDAR_ID={{ calendarId }} MODEL_VERSION={{ modelVersion }} k6 run tests/load/k6-script.js
+  metrics:
+    - response_time_ms (Trend, p50/p95/p99)
+    - error_rate (Rate)
+    - request_throughput (Counter)
+    - builtin http_req_duration/http_reqs (для Grafana dashboards)
+  observability:
+    - use k6 --out cloud|influxdb=http://localhost:8086/k6 для зберігання метрик
+    - Grafana dashboard: https://grafana.com/grafana/dashboards/2587-k6-load-testing/
+
+environments:
+  local:
+    apiBaseUrl: http://localhost:5000
+    editorUrl: http://localhost:4200/editor
+    calendarId: 1
+    modelVersion: flux-pro-v1.1
+  staging:
+    apiBaseUrl: https://staging.api.calendary.local
+    editorUrl: https://staging.calendary.local/editor
+    calendarId: 42
+    modelVersion: flux-pro-v1.1
+
+scenarios:
+  image_generation:
+    description: 10 одночасних генерацій зображень.
+    k6Scenario: image_generation
+    command: >
+      {{ commandTemplate }} --scenario image_generation
+    asserts:
+      responseTimeP95: < 3000 ms
+      errorRate: < 1%
+
+  pdf_generation:
+    description: 5 одночасних генерацій PDF через /api/calendar/generate/{calendarId}.
+    preconditions:
+      - CALENDAR_ID повинен існувати та бути доступним користувачу токена.
+    k6Scenario: pdf_generation
+    command: >
+      {{ commandTemplate }} --scenario pdf_generation
+
+  editor_concurrency:
+    description: 100 concurrent users в /editor.
+    k6Scenario: editor_concurrency
+    command: >
+      {{ commandTemplate }} --scenario editor_concurrency
+
+  spike_test:
+    description: Різкий наплив користувачів на генерацію зображень.
+    k6Scenario: spike_test
+    command: >
+      {{ commandTemplate }} --scenario spike_test
+
+  soak_test:
+    description: Тривале навантаження (1 година) для відстеження стабільності.
+    k6Scenario: soak_test
+    command: >
+      {{ commandTemplate }} --scenario soak_test
+    notes:
+      - Запускати у screen/tmux, використовувати --duration для скороченої локальної перевірки.
+
+metrics_to_track:
+  response_time:
+    description: http_req_duration (p50, p95, p99)
+  throughput:
+    description: request_throughput / http_reqs
+  error_rate:
+    description: error_rate + http_req_failed
+  cpu_usage:
+    description: Знімати через `docker stats` або Prometheus node_exporter
+  memory_usage:
+    description: Слідкувати за pod/container memory (Prometheus/Grafana panels)
+  db_connections:
+    description: sqlserver_current_connections (або еквівалент з chosen DB exporter)
+
+acceptance_criteria:
+  - p95 response time < 3s для всіх сценаріїв
+  - Error rate < 1%
+  - Soak test 60 хвилин без перезапуску сервісів та витоків пам'яті
+  - Середній CPU < 75%, середній memory < 80% від доступного


### PR DESCRIPTION
## Summary
- add a comprehensive k6 script that covers the required image, PDF, editor, spike, and soak load scenarios with shared metrics and thresholds
- document how to launch each scenario plus observability requirements in `tests/load/scenarios.yml`
- mark backlog task 31 as done and describe the created tooling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c09c3248832bb78529d5d41c5c21)