### PR TITLE
Complete stage 1 frontend setup in Calendary.Ng

### DIFF
--- a/epic_02/PROGRESS.md
+++ b/epic_02/PROGRESS.md
@@ -1,0 +1,12 @@
+# Progress Tracker (Calendary.Ng)
+
+## Етап 1 · Фундамент
+
+- [x] **Task 01 – Frontend baseline**  
+  Angular workspace містить lint/type-check/format скрипти, TypeScript strict та документацію (`src/Calendary.Ng`).
+- [x] **Task 02 – UI Kit**  
+  Створено дизайн-токени (`src/styles/_tokens.scss`) і UI-компоненти (`ui-section`, `ui-feature-grid`, `ui-cta-button`).
+- [x] **Task 03 – Routing & Layout**  
+  `MainComponent` розширено спільним лейаутом + `FooterComponent`, домашня сторінка працює через новий UI kit.
+
+> Усі зміни виконані у проєкті `src/Calendary.Ng` (Angular) відповідно до запиту "calendar.ng".

--- a/epic_02/README.md
+++ b/epic_02/README.md
@@ -71,6 +71,8 @@ Task 01 → Task 02 → Task 03
 ```
 Можна робити Task 01 → 02 → 03 послідовно (залежності).
 
+> ✅ **Статус**: Task 01-03 виконані в Angular додатку (`src/Calendary.Ng`). Дивіться [PROGRESS.md](./PROGRESS.md) для деталей.
+
 **Трек B - Backend API (Claude):**
 ```
 Task 04, Task 05, Task 06 (всі паралельно, незалежні)

--- a/src/Calendary.Ng/.eslintrc.json
+++ b/src/Calendary.Ng/.eslintrc.json
@@ -1,0 +1,37 @@
+{
+  "root": true,
+  "ignorePatterns": ["projects/**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@angular-eslint/recommended",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "parserOptions": {
+        "project": ["tsconfig.eslint.json"],
+        "tsconfigRootDir": "./"
+      },
+      "rules": {
+        "@typescript-eslint/explicit-function-return-type": "off",
+        "@typescript-eslint/no-explicit-any": "off",
+        "@angular-eslint/component-class-suffix": ["error", {"suffixes": ["Component"]}],
+        "@angular-eslint/directive-selector": [
+          "error",
+          {"type": "attribute", "prefix": "app", "style": "camelCase"}
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {"type": "element", "prefix": "app", "style": "kebab-case"}
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@angular-eslint/template/recommended"],
+      "rules": {
+        "@angular-eslint/template/no-autofocus": "off"
+      }
+    }
+  ]
+}

--- a/src/Calendary.Ng/.prettierrc
+++ b/src/Calendary.Ng/.prettierrc
@@ -1,0 +1,15 @@
+{
+  "singleQuote": true,
+  "printWidth": 100,
+  "semi": true,
+  "trailingComma": "all",
+  "tabWidth": 2,
+  "overrides": [
+    {
+      "files": "*.scss",
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
+}

--- a/src/Calendary.Ng/README.md
+++ b/src/Calendary.Ng/README.md
@@ -1,27 +1,49 @@
-# CalendaryNg
+# Calendary.Ng Frontend
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 18.2.8.
+Angular 20.3+ SPA + SSR, що покриває Customer Portal Calendary. На цьому етапі виконано **Етап 1** (Task 01-03) з епіка Customer Portal:
 
-## Development server
+1. **Task 01 – Frontend baseline**: Оновлено структуру проєкту, додано lint/type-check/format скрипти, підготовлено `.eslintrc` та `.prettierrc`.
+2. **Task 02 – UI Kit**: Створено дизайн-токени, секції, CTA-кнопки та грід переваг для повторного використання.
+3. **Task 03 – Routing & Layout**: Головний лейаут тепер містить шапку, контент і новий футер з єдиним стилем.
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The application will automatically reload if you change any of the source files.
+## Скрипти
 
-## Code scaffolding
+| Скрипт | Опис |
+| --- | --- |
+| `npm run dev` / `npm start` | Dev-server на `http://localhost:4200` з proxy до backend. |
+| `npm run build` | Production збірка + SSR bundle (`dist/calendary.ng`). |
+| `npm run test` | Karma unit-тести. |
+| `npm run test:e2e` | Playwright сценарії з `src/Calendary.Ng/e2e`. |
+| `npm run lint` | `ng lint` із @angular-eslint (виконується після `npm install`). |
+| `npm run type-check` | `tsc --noEmit` для статичного аналізу. |
+| `npm run format` / `npm run format:check` | Prettier форматування та перевірка стилю. |
 
-Run `ng generate component component-name` to generate a new component. You can also use `ng generate directive|pipe|service|class|guard|interface|enum|module`.
+> ℹ️ Перший запуск `npm run lint`/`format` вимагає `npm install`, щоб підтягнути devDependencies.
 
-## Build
+## Дизайн система
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory.
+- **Токени**: `src/styles/_tokens.scss` визначає кольори, шрифти, тіні, радіуси, spacing.
+- **Базові стилі**: `src/styles.scss` вмикає глобальні класи (`.app-shell`, `.cta-button`, `.surface-card`, `.tag`).
+- **UI компоненти** (`src/app/components/ui/`):
+  - `section/section.component` – семантичні секції з різними фонами.
+  - `cta-button/cta-button.component` – кнопка з варіантами `primary`/`secondary`.
+  - `feature-grid/feature-grid.component` – грід карток переваг.
 
-## Running unit tests
+## Лейаут та роутинг
 
-Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).
+- `MainComponent` відповідає за спільний шаблон (header → content → footer) та показує loading overlay при блокуванні UI.
+- Новий `FooterComponent` містить швидкі посилання, контакти та рік.
+- `app.routes.ts` залишився джерелом істини для публічних та admin маршрутів; всі публічні сторінки вбудовані у `MainComponent`.
 
-## Running end-to-end tests
+## Домашня сторінка
 
-Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
+`HomeComponent` тепер використовує UI kit:
+- Hero-блок з CTA, статистикою й прев’ю календаря.
+- Грід переваг, які підключені через `FeatureGridComponent`.
+- Таймлайн кроків створення календаря та фінальний call-to-action.
 
-## Further help
+## Подальші кроки
 
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.dev/tools/cli) page.
+- Розширити UI kit компонентами для інших сторінок (каталог, кошик).
+- Підключити lint/format у CI pipeline.
+- Додати сторінки Stage 2 (каталог шаблонів та редактор) на основі створеного фундаменту.

--- a/src/Calendary.Ng/angular.json
+++ b/src/Calendary.Ng/angular.json
@@ -112,6 +112,15 @@
             "scripts": [],
             "karmaConfig": "karma.conf.js"
           }
+        },
+        "lint": {
+          "builder": "@angular-eslint/builder:lint",
+          "options": {
+            "lintFilePatterns": [
+              "src/**/*.ts",
+              "src/**/*.html"
+            ]
+          }
         }
       }
     }
@@ -141,5 +150,8 @@
     "@schematics/angular:resolver": {
       "typeSeparator": "."
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/Calendary.Ng/package.json
+++ b/src/Calendary.Ng/package.json
@@ -4,10 +4,15 @@
   "scripts": {
     "app": "ng serve",
     "ng": "ng",
+    "dev": "ng serve",
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
     "test": "ng test",
+    "lint": "ng lint",
+    "type-check": "tsc --project tsconfig.json --noEmit",
+    "format": "prettier --write \"src/**/*.{ts,tsx,js,json,scss,html,md}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,js,json,scss,html,md}\"",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
@@ -45,6 +50,11 @@
     "zone.js": "~0.15.1"
   },
   "devDependencies": {
+    "@angular-eslint/builder": "^18.3.0",
+    "@angular-eslint/eslint-plugin": "^18.3.0",
+    "@angular-eslint/eslint-plugin-template": "^18.3.0",
+    "@angular-eslint/schematics": "^18.3.0",
+    "@angular-eslint/template-parser": "^18.3.0",
     "@angular-devkit/build-angular": "^20.3.10",
     "@angular/cli": "^20.3.10",
     "@angular/compiler-cli": "^20.3.12",
@@ -53,12 +63,16 @@
     "@types/jasmine": "~5.1.0",
     "@types/jwt-decode": "^3.1.0",
     "@types/node": "^18.18.0",
+    "eslint": "^8.57.1",
+    "eslint-config-prettier": "^9.1.0",
     "jasmine-core": "~5.2.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.2.0",
     "karma-coverage": "~2.2.0",
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "~2.1.0",
+    "prettier": "^3.2.5",
+    "prettier-plugin-organize-imports": "^4.0.0",
     "typescript": "~5.9.3"
   }
 }

--- a/src/Calendary.Ng/src/app/components/footer/footer.component.html
+++ b/src/Calendary.Ng/src/app/components/footer/footer.component.html
@@ -1,0 +1,29 @@
+<footer class="app-footer">
+  <div class="app-footer__grid">
+    <div>
+      <p class="app-footer__eyebrow">Calendary</p>
+      <p class="app-footer__description">
+        Платформа для створення персоналізованих календарів з AI-генерацією і друком на замовлення.
+      </p>
+    </div>
+    <div>
+      <p class="app-footer__eyebrow">Швидкі посилання</p>
+      <ul>
+        <li *ngFor="let link of quickLinks">
+          <a [href]="link.href">{{ link.label }}</a>
+        </li>
+      </ul>
+    </div>
+    <div>
+      <p class="app-footer__eyebrow">Підтримка</p>
+      <ul>
+        <li><a href="mailto:support@calendary.com.ua">support@calendary.com.ua</a></li>
+        <li><span>+380 (66) 000-00-00</span></li>
+      </ul>
+    </div>
+  </div>
+  <div class="app-footer__meta">
+    <span>© {{ year }} Calendary. Всі права захищені.</span>
+    <span>Зроблено з ❤️ в Україні</span>
+  </div>
+</footer>

--- a/src/Calendary.Ng/src/app/components/footer/footer.component.scss
+++ b/src/Calendary.Ng/src/app/components/footer/footer.component.scss
@@ -1,0 +1,46 @@
+.app-footer {
+  padding: var(--space-8) var(--space-4);
+  margin-top: var(--space-12);
+  background: var(--color-surface);
+  border-top: 1px solid var(--color-border);
+}
+
+.app-footer__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-6);
+  margin-bottom: var(--space-6);
+}
+
+.app-footer__eyebrow {
+  font-weight: 600;
+  margin-bottom: var(--space-2);
+}
+
+.app-footer__description {
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.app-footer ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.app-footer a {
+  color: var(--color-text);
+  text-decoration: none;
+}
+
+.app-footer__meta {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: var(--color-text-muted);
+  gap: 1rem;
+}

--- a/src/Calendary.Ng/src/app/components/footer/footer.component.ts
+++ b/src/Calendary.Ng/src/app/components/footer/footer.component.ts
@@ -1,0 +1,19 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-footer',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './footer.component.html',
+  styleUrl: './footer.component.scss',
+})
+export class FooterComponent {
+  readonly year = new Date().getFullYear();
+
+  readonly quickLinks = [
+    { label: 'Каталог шаблонів', href: '/master' },
+    { label: 'Редактор', href: '/editor' },
+    { label: 'Кошик', href: '/cart' },
+  ];
+}

--- a/src/Calendary.Ng/src/app/components/ui/cta-button/cta-button.component.html
+++ b/src/Calendary.Ng/src/app/components/ui/cta-button/cta-button.component.html
@@ -1,0 +1,6 @@
+<button type="button" class="cta-button" [ngClass]="'cta-button--' + variant" (click)="emit($event)">
+  <ng-container *ngIf="label; else projected">{{ label }}</ng-container>
+  <ng-template #projected>
+    <ng-content></ng-content>
+  </ng-template>
+</button>

--- a/src/Calendary.Ng/src/app/components/ui/cta-button/cta-button.component.scss
+++ b/src/Calendary.Ng/src/app/components/ui/cta-button/cta-button.component.scss
@@ -1,0 +1,3 @@
+:host {
+  display: inline-flex;
+}

--- a/src/Calendary.Ng/src/app/components/ui/cta-button/cta-button.component.ts
+++ b/src/Calendary.Ng/src/app/components/ui/cta-button/cta-button.component.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'ui-cta-button',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './cta-button.component.html',
+  styleUrl: './cta-button.component.scss',
+})
+export class CtaButtonComponent {
+  @Input() variant: 'primary' | 'secondary' = 'primary';
+  @Input() label = '';
+  @Output() action = new EventEmitter<Event>();
+
+  emit(event: Event) {
+    event.preventDefault();
+    this.action.emit(event);
+  }
+}

--- a/src/Calendary.Ng/src/app/components/ui/feature-grid/feature-grid.component.html
+++ b/src/Calendary.Ng/src/app/components/ui/feature-grid/feature-grid.component.html
@@ -1,0 +1,9 @@
+<div class="feature-grid">
+  <article class="feature-card" *ngFor="let feature of features">
+    <div class="feature-card__icon" [attr.aria-hidden]="true" [ngClass]="feature.accent">
+      {{ feature.icon }}
+    </div>
+    <h3>{{ feature.title }}</h3>
+    <p>{{ feature.description }}</p>
+  </article>
+</div>

--- a/src/Calendary.Ng/src/app/components/ui/feature-grid/feature-grid.component.scss
+++ b/src/Calendary.Ng/src/app/components/ui/feature-grid/feature-grid.component.scss
@@ -1,0 +1,43 @@
+@use '../../../../styles/tokens' as *;
+
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.feature-card {
+  @include surface-card;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.feature-card__icon {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-pill);
+  display: grid;
+  place-items: center;
+  font-size: 1.5rem;
+  background: rgba(91, 61, 226, 0.12);
+}
+
+.feature-card__icon.accent {
+  background: rgba(255, 138, 92, 0.2);
+}
+
+.feature-card__icon.neutral {
+  background: rgba(12, 18, 34, 0.08);
+}
+
+.feature-card h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.feature-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}

--- a/src/Calendary.Ng/src/app/components/ui/feature-grid/feature-grid.component.ts
+++ b/src/Calendary.Ng/src/app/components/ui/feature-grid/feature-grid.component.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+export interface FeatureCard {
+  title: string;
+  description: string;
+  icon?: string;
+  accent?: 'primary' | 'accent' | 'neutral';
+}
+
+@Component({
+  selector: 'ui-feature-grid',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './feature-grid.component.html',
+  styleUrl: './feature-grid.component.scss',
+})
+export class FeatureGridComponent {
+  @Input() features: FeatureCard[] = [];
+}

--- a/src/Calendary.Ng/src/app/components/ui/section/section.component.html
+++ b/src/Calendary.Ng/src/app/components/ui/section/section.component.html
@@ -1,0 +1,14 @@
+<section class="ui-section" [ngClass]="sectionClasses">
+  <div class="ui-section__inner">
+    <div class="ui-section__header" [ngClass]="headerAlignment">
+      <p class="ui-section__eyebrow" *ngIf="eyebrow">{{ eyebrow }}</p>
+      <div>
+        <h2 *ngIf="title">{{ title }}</h2>
+        <p class="ui-section__subtitle" *ngIf="subtitle">{{ subtitle }}</p>
+      </div>
+    </div>
+    <div class="ui-section__content">
+      <ng-content></ng-content>
+    </div>
+  </div>
+</section>

--- a/src/Calendary.Ng/src/app/components/ui/section/section.component.scss
+++ b/src/Calendary.Ng/src/app/components/ui/section/section.component.scss
@@ -1,0 +1,70 @@
+@use '../../../../styles/tokens' as *;
+
+.ui-section {
+  padding: var(--space-12) var(--space-4);
+}
+
+.ui-section--surface {
+  background: var(--color-surface);
+}
+
+.ui-section--muted {
+  background: var(--color-surface-muted);
+}
+
+.ui-section--highlight {
+  background: radial-gradient(circle at top, rgba(255, 255, 255, 0.2), transparent),
+    var(--gradient-hero);
+  color: #fff;
+}
+
+.ui-section--highlight .ui-section__subtitle {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.ui-section--highlight .ui-section__eyebrow {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+.ui-section__inner {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.ui-section__header {
+  text-align: left;
+  margin-bottom: var(--space-6);
+}
+
+.ui-section__header h2 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin: 0;
+}
+
+.ui-section__subtitle {
+  margin: var(--space-3) 0 0;
+  color: var(--color-text-muted);
+}
+
+.ui-section__eyebrow {
+  @include text-label;
+  color: var(--color-primary);
+  margin-bottom: var(--space-2);
+}
+
+.ui-section__header--center {
+  text-align: center;
+}
+
+.ui-section__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+@media (max-width: 768px) {
+  .ui-section {
+    padding: var(--space-8) var(--space-3);
+  }
+}

--- a/src/Calendary.Ng/src/app/components/ui/section/section.component.ts
+++ b/src/Calendary.Ng/src/app/components/ui/section/section.component.ts
@@ -1,0 +1,34 @@
+import { CommonModule, NgClass } from '@angular/common';
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'ui-section',
+  standalone: true,
+  imports: [CommonModule, NgClass],
+  templateUrl: './section.component.html',
+  styleUrl: './section.component.scss',
+})
+export class SectionComponent {
+  @Input() title = '';
+  @Input() subtitle = '';
+  @Input() eyebrow = '';
+  @Input() alignment: 'left' | 'center' = 'center';
+  @Input() variant: 'default' | 'surface' | 'muted' | 'highlight' = 'default';
+  @Input() fullWidth = false;
+
+  get sectionClasses() {
+    return {
+      'ui-section--surface': this.variant === 'surface',
+      'ui-section--muted': this.variant === 'muted',
+      'ui-section--highlight': this.variant === 'highlight',
+      'ui-section--full': this.fullWidth,
+    };
+  }
+
+  get headerAlignment() {
+    return {
+      'ui-section__header--center': this.alignment === 'center',
+      'ui-section__header--left': this.alignment === 'left',
+    };
+  }
+}

--- a/src/Calendary.Ng/src/app/main.component.html
+++ b/src/Calendary.Ng/src/app/main.component.html
@@ -1,4 +1,10 @@
-<div *ngIf="isBlocked$ | async" class="loading-overlay">
+<div class="app-shell">
+  <div *ngIf="isBlocked$ | async" class="loading-overlay" aria-live="polite">
+    <div class="loading-overlay__spinner" role="status" aria-label="Виконується операція"></div>
+  </div>
+  <app-header class="app-shell__header"></app-header>
+  <main class="app-shell__content">
+    <router-outlet />
+  </main>
+  <app-footer class="app-shell__footer"></app-footer>
 </div>
-<app-header></app-header>
-<router-outlet />

--- a/src/Calendary.Ng/src/app/main.component.scss
+++ b/src/Calendary.Ng/src/app/main.component.scss
@@ -1,12 +1,16 @@
+:host {
+  display: block;
+}
+
 .loading-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-  }
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 9999;
+}

--- a/src/Calendary.Ng/src/app/main.component.ts
+++ b/src/Calendary.Ng/src/app/main.component.ts
@@ -4,11 +4,12 @@ import { HeaderComponent } from './components/header/header.component';
 import { BlockUiService } from '../services/block.ui.service';
 import { Observable } from 'rxjs';
 import { CommonModule } from '@angular/common';
+import { FooterComponent } from './components/footer/footer.component';
 
 @Component({
     selector: 'app-main',
     standalone: true,
-    imports: [CommonModule, RouterOutlet, HeaderComponent],
+    imports: [CommonModule, RouterOutlet, HeaderComponent, FooterComponent],
     templateUrl: './main.component.html',
     styleUrl: './main.component.scss'
 })

--- a/src/Calendary.Ng/src/app/pages/home/home.component.html
+++ b/src/Calendary.Ng/src/app/pages/home/home.component.html
@@ -1,35 +1,76 @@
-<section class="hero background-white">
-    <div class="content" style="text-align: center;">
-        <img [src]="'/images/bg_title.jpg'" alt="Calendary Background" class="illustration"
-            style="max-width: 100%; height: auto;">
-        <h2>Ваш персональний календар – спогади на кожен день!</h2>
-        <p>
-            <strong>Calendary</strong> – це не просто сервіс для створення календарів. Ми перетворюємо ваші спогади на
-            справжні витвори мистецтва
-            за допомогою передових технологій штучного інтелекту.
-        </p>
-        <button (click)="goToMaster()" class="btn-primary">Створити календар</button>
-        <img [src]="'/images/poster_in_room.png'" alt="Poster in Room" class="illustration"
-            style="max-width: 80%; height: auto; margin-top: 20px;">
+<ui-section
+  variant="highlight"
+  alignment="center"
+  eyebrow="AI студія календарів"
+  title="Створіть персональний календар за кілька хвилин"
+  subtitle="Генеруйте ілюстрації, редагуйте календар та замовляйте друк онлайн."
+>
+  <div class="hero-grid">
+    <div class="hero-grid__content">
+      <p class="hero-grid__subtitle">
+        Calendary поєднує генеративний AI та класичний друк: від ідеї до готового постера з доставкою по Україні.
+      </p>
+      <div class="hero-grid__cta">
+        <ui-cta-button (action)="goToMaster()">Створити календар</ui-cta-button>
+        <span class="hero-grid__note">3 генерації безкоштовно • Без встановлення</span>
+      </div>
+      <div class="hero-grid__stats">
+        <div>
+          <span class="hero-grid__stat-number">12+</span>
+          <span class="hero-grid__stat-label">AI-стилів</span>
+        </div>
+        <div>
+          <span class="hero-grid__stat-number">5 хв.</span>
+          <span class="hero-grid__stat-label">до готового макета</span>
+        </div>
+        <div>
+          <span class="hero-grid__stat-number">100%</span>
+          <span class="hero-grid__stat-label">контроль друку</span>
+        </div>
+      </div>
     </div>
-</section>
+    <div class="hero-grid__media surface-card">
+      <img
+        ngSrc="/images/bg_title.jpg"
+        width="640"
+        height="420"
+        alt="Приклад дизайнерського календаря"
+      />
+      <div class="hero-grid__media-card">
+        <strong>Автоматичний попередній перегляд</strong>
+        <p>Система підказує, коли всі 12 місяців заповнені та готові до експорту в PDF.</p>
+      </div>
+    </div>
+  </div>
+</ui-section>
 
-<section class="ai-features background-white">
-    <div class="content">
-        <h2>Переваги Calendary</h2>
-        <p>Чому обрати нас?</p>
-        <ul>
-            <li><strong>Штучний інтелект на службі ваших спогадів:</strong> Ми створюємо персоналізовані ілюстрації, які
-                вас вразять.</li>
-            <li><strong>Персоналізація в кожній деталі:</strong> Календар відображає ваш стиль, мрії та найважливіші
-                моменти.</li>
-            <li><strong>Простота і задоволення:</strong> Легкий процес створення, який приносить радість.</li>
-        </ul>
-        <p>Ваш календар стане справжнім витвором мистецтва, який буде надихати кожного дня!</p>
-        <p>
-            <img [src]="'/images/poster_on_wall.png'" alt="Poster on Wall" class="illustration"
-                style="max-width: 70%; height: auto; margin-top: 20px;">
-            <button (click)="goToMaster()" class="btn-primary">Створити календар</button>
-        </p>
+<ui-section
+  alignment="center"
+  title="Переваги Calendary"
+  subtitle="Інструменти, які прискорюють створення календаря"
+>
+  <ui-feature-grid [features]="features"></ui-feature-grid>
+</ui-section>
+
+<ui-section alignment="left" variant="surface" title="Як працює майстер Calendary?">
+  <ol class="workflow-list">
+    <li *ngFor="let step of workflowSteps; index as i">
+      <div class="workflow-list__index">{{ i + 1 }}</div>
+      <div>
+        <h3>{{ step.title }}</h3>
+        <p>{{ step.description }}</p>
+      </div>
+    </li>
+  </ol>
+</ui-section>
+
+<ui-section alignment="center" variant="muted">
+  <div class="closing-cta surface-card">
+    <h3>Готові розпочати?</h3>
+    <p>Перейдіть у майстер, щоб сформувати календар і додати його до кошика.</p>
+    <div class="closing-cta__actions">
+      <ui-cta-button (action)="goToMaster()">Відкрити майстер</ui-cta-button>
+      <a routerLink="/register" class="closing-cta__link">Зареєструватись</a>
     </div>
-</section>
+  </div>
+</ui-section>

--- a/src/Calendary.Ng/src/app/pages/home/home.component.scss
+++ b/src/Calendary.Ng/src/app/pages/home/home.component.scss
@@ -1,135 +1,135 @@
-/* Загальні стилі */
-body {
-  font-family: Arial, sans-serif;
+:host {
+  display: block;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: var(--space-6);
+  align-items: center;
+}
+
+.hero-grid__content h1,
+.hero-grid__content h2 {
   margin: 0;
-  padding: 0;
-  line-height: 1.6;
 }
 
-h2 {
-  font-size: 2rem;
-  margin-bottom: 1rem;
-  color: #333;
-  text-align: center;
+.hero-grid__subtitle {
+  margin: 0 0 var(--space-4);
+  color: rgba(255, 255, 255, 0.85);
+  max-width: 560px;
 }
 
-p {
-  font-size: 1rem;
-  color: #555;
-  text-align: center;
+.hero-grid__cta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
 }
 
-
-ul, ol {
-  margin: 20px auto;
-  padding: 0 20px;
-  list-style-type: none;
-  max-width: 800px;
-  color: #555;
-}
-
-ul li, ol li {
-  margin-bottom: 10px;
-  font-size: 1rem;
-}
-
-/* Секції */
-.hero {
-  padding: 50px 20px;
-  background-color: #ffffff;
-  text-align: center;
-}
-
-.background-gray {
-  background-color: #f8f9fa;
-  padding: 50px 20px;
-}
-
-.background-white {
-  background-color: #ffffff;
-  padding: 50px 20px;
-}
-
-.content {
-  max-width: 900px;
-  margin: 0 auto;
-}
-
-/* Зображення */
-.illustration {
-  max-width: 100%;
-  height: auto;
-  margin-top: 20px;
-}
-
-/* Футер */
-.footer {
-  text-align: center;
-  background-color: #333;
-  color: white;
-  padding: 20px 0;
-}
-
-.footer p {
-  margin: 0;
+.hero-grid__note {
   font-size: 0.9rem;
-}
-/* Кнопки */
-button, .btn-primary {
-    display: inline-block;
-    padding: 12px 25px;
-    background-color: #007BFF;
-    color: #fff;
-    text-decoration: none;
-    border-radius: 5px;
-    font-size: 1rem;
-    transition: background-color 0.3s ease;
-    text-align: center;
-    margin: 20px auto; /* Відступи зверху та знизу */
+  color: rgba(255, 255, 255, 0.8);
 }
 
-button:hover, .btn-primary:hover {
-    background-color: #0056b3;
+.hero-grid__stats {
+  margin-top: var(--space-6);
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: var(--space-4);
 }
 
-/* Центрування кнопок */
-button, .btn-primary {
-    display: block;
-    width: fit-content;
-    margin: 20px auto; /* Вирівнювання по центру сторінки */
+.hero-grid__stat-number {
+  display: block;
+  font-size: 1.8rem;
+  font-weight: 700;
 }
 
-/* Адаптивність */
-@media (max-width: 768px) {
-  h2 {
-      font-size: 1.8rem;
-  }
-
-  p {
-      font-size: 0.9rem;
-  }
-
-  button {
-      font-size: 0.9rem;
-      padding: 8px 16px;
-  }
-
-  ul li, ol li {
-      font-size: 0.9rem;
-  }
+.hero-grid__stat-label {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.85);
 }
 
-@media (max-width: 480px) {
-  h2 {
-      font-size: 1.5rem;
+.hero-grid__media {
+  position: relative;
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.hero-grid__media img {
+  border-radius: calc(var(--radius-base) - 6px);
+}
+
+.hero-grid__media-card {
+  background: var(--color-surface);
+  border-radius: var(--radius-base);
+  padding: var(--space-3);
+  box-shadow: var(--shadow-card);
+}
+
+.workflow-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.workflow-list li {
+  display: flex;
+  gap: var(--space-4);
+  align-items: center;
+}
+
+.workflow-list__index {
+  width: 48px;
+  height: 48px;
+  border-radius: 16px;
+  background: rgba(91, 61, 226, 0.12);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.workflow-list h3 {
+  margin: 0 0 0.25rem;
+}
+
+.workflow-list p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.closing-cta {
+  text-align: center;
+  padding: var(--space-8) var(--space-4);
+}
+
+.closing-cta__actions {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  align-items: center;
+}
+
+.closing-cta__link {
+  color: var(--color-primary);
+  text-decoration: none;
+  font-weight: 600;
+}
+
+@media (min-width: 768px) {
+  .hero-grid__cta {
+    flex-direction: row;
+    align-items: center;
   }
 
-  p {
-      font-size: 0.8rem;
-  }
-
-  button {
-      font-size: 0.8rem;
-      padding: 6px 12px;
+  .closing-cta__actions {
+    flex-direction: row;
   }
 }

--- a/src/Calendary.Ng/src/app/pages/home/home.component.ts
+++ b/src/Calendary.Ng/src/app/pages/home/home.component.ts
@@ -1,13 +1,67 @@
+import { CommonModule, NgOptimizedImage } from '@angular/common';
 import { Component } from '@angular/core';
-import { Router } from '@angular/router';
+import { Router, RouterLink } from '@angular/router';
+import { CtaButtonComponent } from '@ui/cta-button/cta-button.component';
+import { SectionComponent } from '@ui/section/section.component';
+import { FeatureCard, FeatureGridComponent } from '@ui/feature-grid/feature-grid.component';
 
 @Component({
     standalone: true,
     selector: 'app-home',
+    imports: [
+      CommonModule,
+      RouterLink,
+      NgOptimizedImage,
+      CtaButtonComponent,
+      SectionComponent,
+      FeatureGridComponent,
+    ],
     templateUrl: './home.component.html',
     styleUrl: './home.component.scss'
 })
 export class HomeComponent {
+  readonly features: FeatureCard[] = [
+    {
+      title: 'AI-генерація стилізованих зображень',
+      description: 'Replicate моделі допомагають створити 12 ілюстрацій у вибраному стилі без складних налаштувань.',
+      icon: '✨',
+      accent: 'primary',
+    },
+    {
+      title: 'Drag & Drop редактор',
+      description: 'Розміщуйте ілюстрації по місяцях, додавайте важливі дати й одразу бачте результат.',
+      icon: '🗓️',
+      accent: 'neutral',
+    },
+    {
+      title: 'Друк та доставка в Україні',
+      description: 'Готовий PDF надсилається у друкарню, а готове замовлення доставляє Нова Пошта.',
+      icon: '📦',
+      accent: 'accent',
+    },
+    {
+      title: 'Особистий кабінет',
+      description: 'Зберігайте дизайн, повторюйте замовлення та відстежуйте статуси оплати й доставки.',
+      icon: '🔐',
+      accent: 'neutral',
+    },
+  ];
+
+  readonly workflowSteps = [
+    {
+      title: 'Завантажте або згенеруйте зображення',
+      description: 'Підкажіть AI бажаний стиль або завантажте власні фотографії та застосуйте швидкі фільтри.',
+    },
+    {
+      title: 'Розмістіть моменти по місяцях',
+      description: 'Перетягуйте ілюстрації, додавайте нагадування й кольорові мітки подій у календарній сітці.',
+    },
+    {
+      title: 'Оформіть замовлення',
+      description: 'Додайте календар до кошика, оберіть доставку та оплату через MonoBank або банківську карту.',
+    },
+  ];
+
   constructor(private router: Router) { }
 
   goToMaster() {

--- a/src/Calendary.Ng/src/styles.scss
+++ b/src/Calendary.Ng/src/styles.scss
@@ -1,58 +1,149 @@
-/* You can add global styles to this file, and also import other style files */
-body {
-    font-family: Arial, sans-serif;
-}
+@use './styles/tokens' as *;
 
-
-h1,
-h2,
-h3,
-h4,
-h5,
-h6,
-p,
-div,
-span,
-a,
-button {
-    font-family: Arial, sans-serif;
-}
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-
-
-*,
-*::before,
-*::after {
+* {
   box-sizing: border-box;
 }
 
-html, body { height: 100%; }
-body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
-
-
-.cdk-drag {
-  background: #f9f9f9;
-  border: 2px dashed #ccc;
-  
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }  
+html,
+body {
+  min-height: 100%;
 }
 
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  color: var(--color-text);
+  background: var(--color-background);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
 
+a {
+  color: inherit;
+}
 
-.cdk-drag-preview {
-  background: #f9f9f9;
-  border: 2px dashed #ccc;
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.app-shell__content {
+  flex: 1;
+  background: var(--color-background);
+}
+
+.app-shell__footer {
+  background: transparent;
+}
+
+.button-reset {
+  border: none;
+  background: none;
+  font: inherit;
+}
+
+.cta-button {
+  border: none;
+  cursor: pointer;
+  border-radius: var(--radius-pill);
+  padding: 0.9rem 1.8rem;
+  font-size: 1rem;
+  font-weight: 600;
+  transition: transform 150ms ease, box-shadow 200ms ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.cta-button--primary {
+  background: var(--color-primary);
+  color: #fff;
+  box-shadow: var(--shadow-soft);
+}
+
+.cta-button--primary:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 25px 35px rgba(91, 61, 226, 0.25);
+}
+
+.cta-button--secondary {
+  background: var(--color-surface);
+  color: var(--color-primary);
+  border: 1px solid rgba(91, 61, 226, 0.2);
+}
+
+.surface-card {
+  @include surface-card;
+}
+
+.tag {
+  @include text-label;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: var(--radius-pill);
+  background: rgba(91, 61, 226, 0.08);
+  color: var(--color-primary);
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }  
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+.loading-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(10, 9, 24, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+  z-index: 9999;
+}
+
+.loading-overlay__spinner {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.35);
+  border-top-color: #fff;
+  animation: spin 0.9s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.cdk-drag,
+.cdk-drag-preview {
+  background: var(--color-surface);
+  border: 2px dashed rgba(12, 18, 34, 0.2);
+  border-radius: var(--radius-base);
+  overflow: hidden;
+}
+
+.cdk-drag img,
+.cdk-drag-preview img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
 }
 
 .full-screen-dialog .mat-dialog-container {

--- a/src/Calendary.Ng/src/styles/_tokens.scss
+++ b/src/Calendary.Ng/src/styles/_tokens.scss
@@ -1,0 +1,37 @@
+:root {
+  --color-background: #f5f5fb;
+  --color-surface: #ffffff;
+  --color-surface-muted: #f0f4ff;
+  --color-primary: #5b3de2;
+  --color-primary-strong: #3b1cb3;
+  --color-accent: #ff8a5c;
+  --color-text: #0b1a2b;
+  --color-text-muted: #4b5565;
+  --color-border: rgba(12, 18, 34, 0.08);
+  --gradient-hero: linear-gradient(135deg, #5b3de2 0%, #9e77ed 50%, #ffc8dd 100%);
+  --radius-base: 18px;
+  --radius-pill: 999px;
+  --shadow-soft: 0 20px 45px rgba(35, 29, 67, 0.12);
+  --shadow-card: 0 12px 30px rgba(26, 19, 57, 0.1);
+  --font-display: 'Manrope', 'Inter', 'Segoe UI', system-ui, sans-serif;
+  --font-body: 'Inter', 'Segoe UI', system-ui, sans-serif;
+  --space-2: 0.5rem;
+  --space-3: 0.75rem;
+  --space-4: 1rem;
+  --space-6: 1.5rem;
+  --space-8: 2rem;
+  --space-12: 3rem;
+}
+
+@mixin surface-card {
+  background-color: var(--color-surface);
+  border-radius: var(--radius-base);
+  border: 1px solid var(--color-border);
+  box-shadow: var(--shadow-card);
+}
+
+@mixin text-label {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}

--- a/src/Calendary.Ng/tsconfig.eslint.json
+++ b/src/Calendary.Ng/tsconfig.eslint.json
@@ -1,0 +1,15 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.e2e-spec.ts",
+    "src/tests/**"
+  ]
+}

--- a/src/Calendary.Ng/tsconfig.json
+++ b/src/Calendary.Ng/tsconfig.json
@@ -6,7 +6,8 @@
     "baseUrl": "./src",
     "paths": {
       "@models/*": ["models/*"],
-      "@services/*": ["services/*"]
+      "@services/*": ["services/*"],
+      "@ui/*": ["app/components/ui/*"]
     },
     "outDir": "./dist/out-tsc",
     "strict": true,


### PR DESCRIPTION
## Summary
- add lint/format/type-check scripts plus ESLint/Prettier config so Calendary.Ng can act as the Stage 1 frontend baseline
- introduce reusable UI kit primitives (design tokens, CTA button, section wrapper, feature grid) and update the home page to use them alongside a refreshed footer/layout
- document the new foundation and mark Epic 02 Stage 1 tasks as completed for the Angular client

## Testing
- `npm run build`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a1c0bb4fc832b8521e4735fc0e619)