### PR TITLE
Add cart store and checkout flow

### DIFF
--- a/src/Calendary.Ng/src/app/app.routes.ts
+++ b/src/Calendary.Ng/src/app/app.routes.ts
@@ -29,6 +29,7 @@ import { AdminUserViewComponent } from './admin/pages/admin-user/admin-user-view
 import { AdminUserSynthesisComponent } from './admin/pages/admin-user/admin-user-view/synthesis/synthesis.component';
 import { EditorComponent } from './pages/editor/editor.component';
 import { CatalogComponent } from './pages/catalog/catalog.component';
+import { CheckoutComponent } from './pages/checkout/checkout.component';
 
 
 export const routes: Routes = [
@@ -70,6 +71,7 @@ export const routes: Routes = [
       { path: 'catalog', component: CatalogComponent },
       { path: 'profile', component: ProfileComponent, canActivate: [UserGuard] },
       { path: 'cart', component: CartComponent, canActivate: [UserGuard]  },
+      { path: 'checkout', component: CheckoutComponent, canActivate: [UserGuard] },
       { path: 'order/:orderId', component: OrderComponent },
       { path: 'master', component: ModelWizardComponent, canActivate: [UserGuard]  },
       { path: 'create-model', component: ModelWizardComponent, canActivate: [UserGuard]  },

--- a/src/Calendary.Ng/src/app/components/cart/cart-item/cart-item.component.html
+++ b/src/Calendary.Ng/src/app/components/cart/cart-item/cart-item.component.html
@@ -1,0 +1,48 @@
+<div class="cart-item-card">
+  <div class="cart-item-media" [class.cart-item-media--empty]="!item.calendar?.previewPath">
+    <img
+      *ngIf="item.calendar?.previewPath"
+      [src]="item.calendar?.previewPath"
+      alt="Попередній перегляд календаря"
+      (click)="requestPreview()"
+    />
+    <div *ngIf="!item.calendar?.previewPath" class="cart-item-placeholder">
+      <p>Прев'ю недоступне</p>
+      <a [routerLink]="['/master']">Продовжити редагування</a>
+    </div>
+  </div>
+
+  <div class="cart-item-details">
+    <div>
+      <p class="cart-item-title">Календар №{{ item.calendar?.id || item.id }}</p>
+      <p class="cart-item-meta">Рік: {{ item.calendar?.year || 'поточний' }}</p>
+    </div>
+
+    <div class="cart-item-controls">
+      <label for="qty-{{ item.id }}">Кількість</label>
+      <input
+        id="qty-{{ item.id }}"
+        type="number"
+        min="1"
+        [disabled]="disabled"
+        [value]="quantity"
+        (input)="handleQuantityInput($any($event.target).value)"
+        (blur)="submitQuantityChange()"
+      />
+    </div>
+
+    <div class="cart-item-actions">
+      <button type="button" (click)="requestPreview()" [disabled]="disabled || !item.calendar?.previewPath">
+        Переглянути
+      </button>
+      <button type="button" class="danger" (click)="remove.emit()" [disabled]="disabled">
+        Видалити
+      </button>
+    </div>
+  </div>
+
+  <div class="cart-item-price">
+    <span class="price">{{ item.price * item.quantity | number:'1.0-0' }} грн</span>
+    <span class="unit-price">{{ item.price | number:'1.0-0' }} грн / од.</span>
+  </div>
+</div>

--- a/src/Calendary.Ng/src/app/components/cart/cart-item/cart-item.component.scss
+++ b/src/Calendary.Ng/src/app/components/cart/cart-item/cart-item.component.scss
@@ -1,0 +1,138 @@
+.cart-item-card {
+  display: grid;
+  grid-template-columns: 180px 1fr 160px;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  background-color: #fff;
+  align-items: center;
+}
+
+.cart-item-media {
+  width: 180px;
+  height: 140px;
+  border-radius: 12px;
+  overflow: hidden;
+  background-color: #f8fafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: zoom-in;
+
+  &--empty {
+    cursor: default;
+  }
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+}
+
+.cart-item-placeholder {
+  text-align: center;
+  font-size: 0.875rem;
+  color: #475569;
+
+  a {
+    display: inline-block;
+    margin-top: 0.5rem;
+    color: #2563eb;
+    text-decoration: none;
+    font-weight: 600;
+  }
+}
+
+.cart-item-details {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.cart-item-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.cart-item-meta {
+  margin: 0;
+  color: #64748b;
+}
+
+.cart-item-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  label {
+    font-weight: 600;
+  }
+
+  input {
+    width: 90px;
+    padding: 0.5rem;
+    border: 1px solid #cbd5f5;
+    border-radius: 8px;
+    font-size: 1rem;
+  }
+}
+
+.cart-item-actions {
+  display: flex;
+  gap: 0.75rem;
+
+  button {
+    border: none;
+    border-radius: 8px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    background-color: #edf2ff;
+    color: #1d4ed8;
+
+    &:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
+    &.danger {
+      background-color: #fee2e2;
+      color: #b91c1c;
+    }
+  }
+}
+
+.cart-item-price {
+  text-align: right;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+
+  .price {
+    font-size: 1.25rem;
+    font-weight: 700;
+  }
+
+  .unit-price {
+    color: #94a3b8;
+    font-size: 0.875rem;
+  }
+}
+
+@media (max-width: 992px) {
+  .cart-item-card {
+    grid-template-columns: 1fr;
+  }
+
+  .cart-item-media {
+    width: 100%;
+  }
+
+  .cart-item-price {
+    text-align: left;
+  }
+}

--- a/src/Calendary.Ng/src/app/components/cart/cart-item/cart-item.component.ts
+++ b/src/Calendary.Ng/src/app/components/cart/cart-item/cart-item.component.ts
@@ -1,0 +1,51 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, OnChanges, Output, SimpleChanges } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { RouterModule } from '@angular/router';
+import { OrderItem } from '../../../../../models/order-item';
+
+@Component({
+  selector: 'app-cart-item',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterModule],
+  templateUrl: './cart-item.component.html',
+  styleUrl: './cart-item.component.scss',
+})
+export class CartItemComponent implements OnChanges {
+  @Input({ required: true }) item!: OrderItem;
+  @Input() disabled = false;
+
+  @Output() quantityChange = new EventEmitter<number>();
+  @Output() remove = new EventEmitter<void>();
+  @Output() preview = new EventEmitter<string>();
+
+  quantity = 1;
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['item'] && this.item) {
+      this.quantity = this.item.quantity;
+    }
+  }
+
+  handleQuantityInput(value: string): void {
+    const parsed = Number(value);
+    if (!Number.isFinite(parsed)) {
+      return;
+    }
+    const next = Math.max(1, Math.floor(parsed));
+    this.quantity = next;
+  }
+
+  submitQuantityChange(): void {
+    if (!this.item || this.quantity === this.item.quantity) {
+      return;
+    }
+    this.quantityChange.emit(this.quantity);
+  }
+
+  requestPreview(): void {
+    if (this.item?.calendar?.previewPath) {
+      this.preview.emit(this.item.calendar.previewPath);
+    }
+  }
+}

--- a/src/Calendary.Ng/src/app/components/cart/cart-summary/cart-summary.component.html
+++ b/src/Calendary.Ng/src/app/components/cart/cart-summary/cart-summary.component.html
@@ -1,0 +1,23 @@
+<div class="summary-card">
+  <h3>Разом</h3>
+  <div class="summary-row">
+    <span>Товарів ({{ totalItems }})</span>
+    <span>{{ subtotal | number:'1.0-0' }} грн</span>
+  </div>
+  <div class="summary-row">
+    <span>Доставка</span>
+    <span *ngIf="shippingCost === 0" class="muted">Розрахується на етапі оплати</span>
+    <span *ngIf="shippingCost > 0">{{ shippingCost | number:'1.0-0' }} грн</span>
+  </div>
+  <div class="summary-total">
+    <span>До сплати</span>
+    <span>{{ total | number:'1.0-0' }} грн</span>
+  </div>
+
+  <button type="button" class="primary" (click)="checkout.emit()" [disabled]="isLoading || totalItems === 0">
+    Оформити замовлення
+  </button>
+  <button type="button" class="secondary" (click)="continueShopping.emit()" [disabled]="isLoading">
+    Продовжити покупки
+  </button>
+</div>

--- a/src/Calendary.Ng/src/app/components/cart/cart-summary/cart-summary.component.scss
+++ b/src/Calendary.Ng/src/app/components/cart/cart-summary/cart-summary.component.scss
@@ -1,0 +1,53 @@
+.summary-card {
+  position: sticky;
+  top: 1.5rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 1.5rem;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.summary-row,
+.summary-total {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.summary-total {
+  font-size: 1.1rem;
+  font-weight: 700;
+  padding-top: 0.75rem;
+  border-top: 1px solid #e2e8f0;
+}
+
+.muted {
+  color: #94a3b8;
+}
+
+button {
+  width: 100%;
+  border-radius: 999px;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+
+  &.primary {
+    background-color: #1d4ed8;
+    color: #fff;
+  }
+
+  &.secondary {
+    background-color: #f8fafc;
+    color: #0f172a;
+  }
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+}

--- a/src/Calendary.Ng/src/app/components/cart/cart-summary/cart-summary.component.ts
+++ b/src/Calendary.Ng/src/app/components/cart/cart-summary/cart-summary.component.ts
@@ -1,0 +1,23 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+@Component({
+  selector: 'app-cart-summary',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './cart-summary.component.html',
+  styleUrl: './cart-summary.component.scss',
+})
+export class CartSummaryComponent {
+  @Input() subtotal = 0;
+  @Input() totalItems = 0;
+  @Input() isLoading = false;
+  @Input() shippingCost = 0;
+
+  @Output() checkout = new EventEmitter<void>();
+  @Output() continueShopping = new EventEmitter<void>();
+
+  get total(): number {
+    return this.subtotal + this.shippingCost;
+  }
+}

--- a/src/Calendary.Ng/src/app/components/cart/empty-cart/empty-cart.component.html
+++ b/src/Calendary.Ng/src/app/components/cart/empty-cart/empty-cart.component.html
@@ -1,0 +1,6 @@
+<div class="empty-cart">
+  <div class="empty-cart__icon">🛒</div>
+  <h2>{{ title }}</h2>
+  <p>{{ description }}</p>
+  <a class="empty-cart__button" [routerLink]="actionLink">{{ actionLabel }}</a>
+</div>

--- a/src/Calendary.Ng/src/app/components/cart/empty-cart/empty-cart.component.scss
+++ b/src/Calendary.Ng/src/app/components/cart/empty-cart/empty-cart.component.scss
@@ -1,0 +1,32 @@
+.empty-cart {
+  text-align: center;
+  padding: 3rem 1rem;
+  border: 2px dashed #cbd5f5;
+  border-radius: 24px;
+  background-color: #f8fafc;
+}
+
+.empty-cart__icon {
+  font-size: 3rem;
+  margin-bottom: 1rem;
+}
+
+.empty-cart h2 {
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+
+.empty-cart p {
+  color: #64748b;
+  margin-bottom: 1.5rem;
+}
+
+.empty-cart__button {
+  display: inline-block;
+  padding: 0.75rem 1.5rem;
+  border-radius: 999px;
+  background-color: #1d4ed8;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 600;
+}

--- a/src/Calendary.Ng/src/app/components/cart/empty-cart/empty-cart.component.ts
+++ b/src/Calendary.Ng/src/app/components/cart/empty-cart/empty-cart.component.ts
@@ -1,0 +1,17 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input } from '@angular/core';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'app-empty-cart',
+  standalone: true,
+  imports: [CommonModule, RouterModule],
+  templateUrl: './empty-cart.component.html',
+  styleUrl: './empty-cart.component.scss',
+})
+export class EmptyCartComponent {
+  @Input() title = 'Ваш кошик порожній';
+  @Input() description = 'Додайте шаблон з каталогу, щоб розпочати оформлення замовлення.';
+  @Input() actionLabel = 'Перейти до каталогу';
+  @Input() actionLink: string | string[] = '/catalog';
+}

--- a/src/Calendary.Ng/src/app/components/checkout/contact-form/contact-form.component.html
+++ b/src/Calendary.Ng/src/app/components/checkout/contact-form/contact-form.component.html
@@ -1,0 +1,54 @@
+<section class="checkout-card" [formGroup]="form">
+  <header>
+    <div>
+      <p class="eyebrow">Крок 1</p>
+      <h2>Контактні дані</h2>
+    </div>
+  </header>
+
+  <div class="form-grid">
+    <label class="form-field">
+      <span>Ім'я *</span>
+      <input type="text" formControlName="firstName" placeholder="Олександр" />
+      <small *ngIf="form.get('firstName')?.invalid && form.get('firstName')?.touched">Ім'я обов'язкове</small>
+    </label>
+
+    <label class="form-field">
+      <span>Прізвище *</span>
+      <input type="text" formControlName="lastName" placeholder="Шевченко" />
+      <small *ngIf="form.get('lastName')?.invalid && form.get('lastName')?.touched">Прізвище обов'язкове</small>
+    </label>
+  </div>
+
+  <label class="form-field">
+    <span>Email *</span>
+    <div class="form-field__row">
+      <input type="email" formControlName="email" placeholder="you@example.com" />
+      <button
+        type="button"
+        class="ghost"
+        (click)="emailVerification.emit()"
+        [disabled]="form.get('email')?.invalid || isEmailConfirmed || isSubmitting"
+      >
+        {{ isEmailConfirmed ? 'Підтверджено' : 'Підтвердити' }}
+      </button>
+    </div>
+    <small *ngIf="form.get('email')?.invalid && form.get('email')?.touched">Вкажіть коректний email</small>
+  </label>
+
+  <label class="form-field">
+    <span>Телефон *</span>
+    <div class="form-field__row">
+      <input type="tel" formControlName="phone" placeholder="+380XXXXXXXXX" />
+      <button
+        type="button"
+        class="ghost"
+        (click)="phoneVerification.emit()"
+        [disabled]="form.get('phone')?.invalid || isPhoneConfirmed || isSubmitting"
+      >
+        {{ isPhoneConfirmed ? 'Підтверджено' : 'Підтвердити' }}
+      </button>
+    </div>
+    <small *ngIf="form.get('phone')?.invalid && form.get('phone')?.touched">Вкажіть номер у форматі +380XXXXXXXXX</small>
+  </label>
+</section>

--- a/src/Calendary.Ng/src/app/components/checkout/contact-form/contact-form.component.scss
+++ b/src/Calendary.Ng/src/app/components/checkout/contact-form/contact-form.component.scss
@@ -1,0 +1,60 @@
+.checkout-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  padding: 1.5rem;
+  background-color: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: #94a3b8;
+  margin: 0;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.95rem;
+
+  input {
+    border: 1px solid #cbd5f5;
+    border-radius: 12px;
+    padding: 0.65rem 0.85rem;
+    font-size: 1rem;
+  }
+
+  small {
+    color: #b91c1c;
+  }
+}
+
+.form-field__row {
+  display: flex;
+  gap: 0.75rem;
+
+  input {
+    flex: 1;
+  }
+
+  button {
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 0.5rem 0.75rem;
+    background-color: #f8fafc;
+    cursor: pointer;
+    &.ghost {
+      background-color: #fff;
+    }
+  }
+}

--- a/src/Calendary.Ng/src/app/components/checkout/contact-form/contact-form.component.ts
+++ b/src/Calendary.Ng/src/app/components/checkout/contact-form/contact-form.component.ts
@@ -1,0 +1,20 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+
+@Component({
+  selector: 'app-contact-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './contact-form.component.html',
+  styleUrl: './contact-form.component.scss',
+})
+export class ContactFormComponent {
+  @Input({ required: true }) form!: FormGroup;
+  @Input() isEmailConfirmed = false;
+  @Input() isPhoneConfirmed = false;
+  @Input() isSubmitting = false;
+
+  @Output() emailVerification = new EventEmitter<void>();
+  @Output() phoneVerification = new EventEmitter<void>();
+}

--- a/src/Calendary.Ng/src/app/components/checkout/delivery-form/delivery-form.component.html
+++ b/src/Calendary.Ng/src/app/components/checkout/delivery-form/delivery-form.component.html
@@ -1,0 +1,58 @@
+<section class="checkout-card" [formGroup]="form">
+  <header>
+    <p class="eyebrow">Крок 2</p>
+    <h2>Доставка</h2>
+  </header>
+
+  <div class="delivery-methods">
+    <label>
+      <input type="radio" value="nova-poshta-warehouse" formControlName="method" />
+      <span>Нова Пошта (у відділення)</span>
+    </label>
+    <label>
+      <input type="radio" value="nova-poshta-courier" formControlName="method" />
+      <span>Нова Пошта (кур'єр)</span>
+    </label>
+    <label>
+      <input type="radio" value="pickup" formControlName="method" />
+      <span>Самовивіз</span>
+    </label>
+  </div>
+
+  <label class="form-field">
+    <span>Місто *</span>
+    <input type="text" formControlName="city" placeholder="Київ" autocomplete="off" />
+    <ul class="suggestions" *ngIf="cityOptions.length">
+      <li *ngFor="let option of cityOptions" (click)="selectCity(option)">
+        {{ option.description }}
+      </li>
+    </ul>
+    <small *ngIf="form.get('city')?.invalid && form.get('city')?.touched">Оберіть місто</small>
+  </label>
+
+  <label class="form-field" *ngIf="shouldShowWarehouse()">
+    <span>Відділення *</span>
+    <input type="text" formControlName="warehouse" placeholder="Відділення №12" autocomplete="off" />
+    <ul class="suggestions" *ngIf="warehouseOptions.length">
+      <li *ngFor="let option of warehouseOptions" (click)="selectWarehouse(option)">
+        {{ option.description }}
+      </li>
+    </ul>
+    <small *ngIf="form.get('warehouse')?.invalid && form.get('warehouse')?.touched">Оберіть відділення</small>
+  </label>
+
+  <div class="form-grid" *ngIf="shouldShowCourierAddress()" formGroupName="address">
+    <label class="form-field">
+      <span>Вулиця *</span>
+      <input type="text" formControlName="street" placeholder="Вулиця" />
+    </label>
+    <label class="form-field">
+      <span>Будинок *</span>
+      <input type="text" formControlName="building" placeholder="10" />
+    </label>
+    <label class="form-field">
+      <span>Квартира</span>
+      <input type="text" formControlName="apartment" placeholder="45" />
+    </label>
+  </div>
+</section>

--- a/src/Calendary.Ng/src/app/components/checkout/delivery-form/delivery-form.component.scss
+++ b/src/Calendary.Ng/src/app/components/checkout/delivery-form/delivery-form.component.scss
@@ -1,0 +1,62 @@
+.checkout-card {
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  padding: 1.5rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.delivery-methods {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+
+  label {
+    display: flex;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    cursor: pointer;
+  }
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+
+  input {
+    padding: 0.65rem 0.85rem;
+    border-radius: 12px;
+    border: 1px solid #cbd5f5;
+  }
+
+  small {
+    color: #b91c1c;
+  }
+}
+
+.suggestions {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  max-height: 200px;
+  overflow-y: auto;
+
+  li {
+    padding: 0.5rem 0.75rem;
+    cursor: pointer;
+  }
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+}

--- a/src/Calendary.Ng/src/app/components/checkout/delivery-form/delivery-form.component.ts
+++ b/src/Calendary.Ng/src/app/components/checkout/delivery-form/delivery-form.component.ts
@@ -1,0 +1,100 @@
+import { CommonModule } from '@angular/common';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { Subject, debounceTime, distinctUntilChanged, of, switchMap, takeUntil } from 'rxjs';
+import { NovaPostItem } from '../../../../../models/nova-post-item';
+import { NovaPostService } from '../../../../../services/novapost.service';
+
+@Component({
+  selector: 'app-delivery-form',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './delivery-form.component.html',
+  styleUrl: './delivery-form.component.scss',
+})
+export class DeliveryFormComponent implements OnInit, OnDestroy {
+  @Input({ required: true }) form!: FormGroup;
+
+  cityOptions: NovaPostItem[] = [];
+  warehouseOptions: NovaPostItem[] = [];
+
+  private destroy$ = new Subject<void>();
+
+  constructor(private readonly novaPostService: NovaPostService) {}
+
+  ngOnInit(): void {
+    const cityControl = this.form.get('city');
+    const warehouseControl = this.form.get('warehouse');
+
+    cityControl?.valueChanges
+      .pipe(
+        takeUntil(this.destroy$),
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((value: string) => {
+          if (!value || value.length < 2) {
+            this.cityOptions = [];
+            return of([]);
+          }
+          return this.novaPostService.searchCity(value);
+        })
+      )
+      .subscribe((options) => {
+        if (Array.isArray(options)) {
+          this.cityOptions = options;
+        }
+      });
+
+    warehouseControl?.valueChanges
+      .pipe(
+        takeUntil(this.destroy$),
+        debounceTime(300),
+        distinctUntilChanged(),
+        switchMap((value: string) => {
+          const method = this.form.get('method')?.value;
+          const city = this.form.get('city')?.value;
+          if (method !== 'nova-poshta-warehouse' || !city || value?.length < 1) {
+            this.warehouseOptions = [];
+            return of([]);
+          }
+          return this.novaPostService.searchWarehouse(city, value);
+        })
+      )
+      .subscribe((options) => {
+        if (Array.isArray(options)) {
+          this.warehouseOptions = options;
+        }
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  selectCity(option: NovaPostItem): void {
+    this.form.patchValue({
+      city: option.description,
+      cityRef: option.ref,
+      warehouse: '',
+      warehouseRef: '',
+    });
+    this.cityOptions = [];
+  }
+
+  selectWarehouse(option: NovaPostItem): void {
+    this.form.patchValue({
+      warehouse: option.description,
+      warehouseRef: option.ref,
+    });
+    this.warehouseOptions = [];
+  }
+
+  shouldShowWarehouse(): boolean {
+    return this.form.get('method')?.value === 'nova-poshta-warehouse';
+  }
+
+  shouldShowCourierAddress(): boolean {
+    return this.form.get('method')?.value === 'nova-poshta-courier';
+  }
+}

--- a/src/Calendary.Ng/src/app/components/checkout/order-summary/order-summary.component.html
+++ b/src/Calendary.Ng/src/app/components/checkout/order-summary/order-summary.component.html
@@ -1,0 +1,37 @@
+<section class="summary" *ngIf="order?.items.length; else emptyState">
+  <h2>Замовлення</h2>
+  <div class="summary-items">
+    <article *ngFor="let item of order?.items" class="summary-item">
+      <div>
+        <p class="summary-item__title">Календар №{{ item.calendar?.id || item.id }}</p>
+        <p class="summary-item__meta">Кількість: {{ item.quantity }}</p>
+      </div>
+      <p class="summary-item__price">{{ item.price * item.quantity | number:'1.0-0' }} грн</p>
+    </article>
+  </div>
+
+  <div class="summary-row">
+    <span>Товарів ({{ totalItems }})</span>
+    <span>{{ subtotal | number:'1.0-0' }} грн</span>
+  </div>
+  <div class="summary-row">
+    <span>Доставка</span>
+    <span *ngIf="deliveryCost === 0" class="muted">Буде уточнено</span>
+    <span *ngIf="deliveryCost > 0">{{ deliveryCost | number:'1.0-0' }} грн</span>
+  </div>
+  <div class="summary-total">
+    <span>До сплати</span>
+    <span>{{ subtotal + deliveryCost | number:'1.0-0' }} грн</span>
+  </div>
+
+  <button type="button" class="primary" (click)="confirm.emit()" [disabled]="isSubmitting">
+    {{ isSubmitting ? 'Обробка...' : 'Перейти до оплати' }}
+  </button>
+  <button type="button" class="secondary" (click)="backToCart.emit()" [disabled]="isSubmitting">
+    Повернутися до кошика
+  </button>
+</section>
+
+<ng-template #emptyState>
+  <app-empty-cart title="Додайте товари перед оформленням" actionLabel="Повернутися до кошика" actionLink="/cart"></app-empty-cart>
+</ng-template>

--- a/src/Calendary.Ng/src/app/components/checkout/order-summary/order-summary.component.scss
+++ b/src/Calendary.Ng/src/app/components/checkout/order-summary/order-summary.component.scss
@@ -1,0 +1,63 @@
+.summary {
+  border: 1px solid #e2e8f0;
+  border-radius: 20px;
+  padding: 1.5rem;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.summary-items {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.summary-item {
+  display: flex;
+  justify-content: space-between;
+}
+
+.summary-item__title {
+  margin: 0;
+  font-weight: 600;
+}
+
+.summary-item__meta {
+  margin: 0;
+  color: #94a3b8;
+}
+
+.summary-row,
+.summary-total {
+  display: flex;
+  justify-content: space-between;
+}
+
+.summary-total {
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+button {
+  width: 100%;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+
+  &.primary {
+    background-color: #22c55e;
+    color: #fff;
+  }
+
+  &.secondary {
+    background-color: #f8fafc;
+  }
+}
+
+.muted {
+  color: #94a3b8;
+}

--- a/src/Calendary.Ng/src/app/components/checkout/order-summary/order-summary.component.ts
+++ b/src/Calendary.Ng/src/app/components/checkout/order-summary/order-summary.component.ts
@@ -1,0 +1,35 @@
+import { CommonModule } from '@angular/common';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { Order } from '../../../../../models/order';
+import { EmptyCartComponent } from '../../cart/empty-cart/empty-cart.component';
+
+@Component({
+  selector: 'app-order-summary',
+  standalone: true,
+  imports: [CommonModule, RouterModule, EmptyCartComponent],
+  templateUrl: './order-summary.component.html',
+  styleUrl: './order-summary.component.scss',
+})
+export class OrderSummaryComponent {
+  @Input() order: Order | null = null;
+  @Input() deliveryCost = 0;
+  @Input() isSubmitting = false;
+
+  @Output() confirm = new EventEmitter<void>();
+  @Output() backToCart = new EventEmitter<void>();
+
+  get subtotal(): number {
+    if (!this.order) {
+      return 0;
+    }
+    return this.order.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  }
+
+  get totalItems(): number {
+    if (!this.order) {
+      return 0;
+    }
+    return this.order.items.reduce((sum, item) => sum + item.quantity, 0);
+  }
+}

--- a/src/Calendary.Ng/src/app/components/header/header.component.html
+++ b/src/Calendary.Ng/src/app/components/header/header.component.html
@@ -15,8 +15,9 @@
         <mat-icon>brush</mat-icon>
         <span>Редактор</span>
       </button>
-      <button *ngIf="isLoggedIn && cartCount && role === 'User'" mat-icon-button [routerLink]="['/cart']" aria-label="Кошик">
+      <button *ngIf="isLoggedIn && role === 'User'" mat-icon-button class="cart-link" [routerLink]="['/cart']" aria-label="Кошик">
         <mat-icon>shopping_cart</mat-icon>
+        <span class="cart-link__badge" *ngIf="cartCount > 0">{{ cartCount }}</span>
       </button>
       <button *ngIf="isLoggedIn && role == 'User'" mat-icon-button [routerLink]="['/profile']" aria-label="Профіль">
         <mat-icon>account_circle</mat-icon>

--- a/src/Calendary.Ng/src/app/components/header/header.component.scss
+++ b/src/Calendary.Ng/src/app/components/header/header.component.scss
@@ -43,3 +43,20 @@
 .icon:hover {
   transform: scale(1.1); /* Slightly enlarge on hover */
 }
+
+.cart-link {
+  position: relative;
+}
+
+.cart-link__badge {
+  position: absolute;
+  top: 0;
+  right: 0;
+  transform: translate(40%, -40%);
+  background: #ef4444;
+  color: #fff;
+  border-radius: 999px;
+  padding: 0 6px;
+  font-size: 0.65rem;
+  line-height: 1.4;
+}

--- a/src/Calendary.Ng/src/app/pages/cart/cart.component.html
+++ b/src/Calendary.Ng/src/app/pages/cart/cart.component.html
@@ -1,46 +1,61 @@
-<div class="cart-container" *ngIf="order">
-  <h2>Кошик</h2>
-  <div class="cart-items">
-    <div *ngFor="let item of order.items" class="cart-item">
-      <span class="title">#{{ item.calendar?.id }}</span>
-      <img *ngIf="item.calendar?.previewPath" [src]="item.calendar?.previewPath" class="thumbnail" (mousedown)="openPreview(item.calendar?.previewPath)"
-        (mouseup)="closePreview()">
-      <a *ngIf="!item.calendar?.previewPath" [routerLink]="['/master']">Продовжити редагування</a>
-      <input class="input" type="number" [(ngModel)]="item.quantity" min="1" (change)="onUpdateItem(item)">
-      <span>{{ item.price }} грн</span>
-      <button (click)="removeItem(item.id)" class="delete-button">видалити</button>
+<section class="cart-page">
+  <header class="cart-page__header">
+    <div>
+      <p class="cart-page__eyebrow">Етап 1 з 2</p>
+      <h1>Кошик</h1>
+      <p class="cart-page__subtitle">Перевірте вибрані календарі перед оформленням доставки.</p>
     </div>
-  </div>
-  
-  <button class="secondary-button" [routerLink]="['/master']">
-    Додати ще календар
-  </button>
+    <button type="button" class="cart-page__refresh" (click)="refreshCart()" [disabled]="isLoading">
+      Оновити
+    </button>
+  </header>
 
-  <div class="total">
-    <h3>Сума</h3>
-    <span class="sum">{{ calculateTotal() }} грн</span>
+  <div *ngIf="loadError" class="cart-page__error">
+    <p>{{ loadError }}</p>
   </div>
 
-  <!-- Поле вводу коментаря -->
-  <div class="comment-section">
-    <h3>Коментар до замовлення</h3>
-    <textarea class="comment-input" [(ngModel)]="order.comment" (blur)="onCommentChange()"
-      placeholder="Додайте коментар..."></textarea>
-  </div>
+  <ng-container *ngIf="!isLoading; else loadingState">
+    <app-empty-cart *ngIf="!hasItems()" actionLabel="Перейти до каталогу" actionLink="/catalog"></app-empty-cart>
 
-  <!-- Підключаємо компонент доставки -->
-  <app-delivery></app-delivery>
-  <p *ngIf="hasIncompleteCalendars()" class="error-message">
-    Завершіть редагування всіх календарів перед переходом до оплати.
-  </p>
-  <button class="checkout-button" (click)="proceedToPayment()" [disabled]="hasIncompleteCalendars()">
-    Перейти до оплати
-  </button>
+    <div *ngIf="hasItems()" class="cart-layout">
+      <div class="cart-items">
+        <app-cart-item
+          *ngFor="let item of order?.items; trackBy: trackByItem"
+          [item]="item"
+          [disabled]="updatingItemId === item.id || removingItemId === item.id"
+          (quantityChange)="onQuantityChange(item, $event)"
+          (remove)="onRemoveItem(item)"
+          (preview)="openPreview($event)"
+        ></app-cart-item>
 
+        <section class="cart-comment">
+          <label for="orderComment">Коментар до замовлення</label>
+          <textarea
+            id="orderComment"
+            rows="4"
+            [(ngModel)]="commentValue"
+            (blur)="onCommentChange()"
+            placeholder="Додайте уточнення або побажання"
+          ></textarea>
+        </section>
+      </div>
 
-  <!-- Модальне вікно для перегляду повного зображення -->
+      <app-cart-summary
+        [totalItems]="totalItems"
+        [subtotal]="subtotal"
+        [isLoading]="isLoading"
+        (checkout)="goToCheckout()"
+        (continueShopping)="continueShopping()"
+      ></app-cart-summary>
+    </div>
+  </ng-container>
+
+  <ng-template #loadingState>
+    <div class="cart-page__loading">Завантаження кошика...</div>
+  </ng-template>
+
   <div class="modal" *ngIf="previewImage">
     <div class="modal-overlay" (click)="closePreview()"></div>
-    <img [src]="previewImage" class="modal-image">
+    <img [src]="previewImage" class="modal-image" />
   </div>
-</div>
+</section>

--- a/src/Calendary.Ng/src/app/pages/cart/cart.component.scss
+++ b/src/Calendary.Ng/src/app/pages/cart/cart.component.scss
@@ -1,171 +1,112 @@
-.cart-container {
-    max-width: 600px;
-    margin: 20px auto;
+.cart-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
 }
 
-h2,
-h3 {
-    color: #3f3d56;
+.cart-page__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.cart-page__eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+  margin-bottom: 0.25rem;
+}
+
+.cart-page__subtitle {
+  color: #64748b;
+  margin: 0;
+}
+
+.cart-page__refresh {
+  border: 1px solid #e2e8f0;
+  background-color: #fff;
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.cart-page__error {
+  padding: 1rem;
+  background-color: #fee2e2;
+  color: #b91c1c;
+  border-radius: 12px;
+  margin-bottom: 1rem;
+}
+
+.cart-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 320px;
+  gap: 2rem;
 }
 
 .cart-items {
-    display: flex;
-    flex-direction: column;
-    padding: 0 3px;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
 }
 
+.cart-comment {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
 
-.thumbnail {
-    width: 150px;
-    height: 50px;
-    object-fit: cover;
-    border-radius: 5px;
-    cursor: pointer;
-  }
-  
-.input {
-    width : 60px;
-}
-.cart-item {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 10px;
-}
-
-.delete-button {
-    background-color: #ff4d4f;
-    color: white;
-    border: none;
-    border-radius: 8px;
-    padding: 10px 15px;
-    font-size: 14px;
-    cursor: pointer;
-
-}
-
-.delete-button:hover {
-    background-color: #e04344;
-}
-
-.total {
-    margin-top: 20px;
-    display: flex;
-    justify-content: flex-end;
-    font-size: 1.2em;
-
-    .sum {
-        color: #3f3d56;
-        font-size: 24pt;
-        margin-left: 20px;
-        line-height: 48px;
-    }
-}
-
-input {
-    border: 1px solid #333;
-    border-radius: 8px;
-    padding: 10px 10px;
-    font-size: 16px;
-}
-
-.error-message {
-    color: red;
-    font-size: 12px;
-}
-
-.comment-section {
-    margin-top: 20px;
-    margin-bottom: 20px;
-  }
-  
-  .comment-input {
-    width: 100%;
-    min-height: 100px;
-    padding: 10px;
-    font-size: 1em;
-    border: 1px solid #ccc;
-    border-radius: 5px;
-    resize: vertical;
+  label {
+    font-weight: 600;
   }
 
-
-.checkout-button {
-    width: 100%;
-    max-width: 400px;
-    padding: 15px;
-    font-size: 18px;
-    font-weight: bold;
-    color: #ffffff;
-    background-color: #2f9606;
-    /* Зелений фон для активної кнопки */
-    border: none;
+  textarea {
     border-radius: 12px;
-    cursor: pointer;
-    transition: background-color 0.3s ease;
-    margin: 10px auto 40px auto;
-
-    
-    &:disabled {
-    background-color: #cccccc; /* Сірий фон для неактивної кнопки */
-    color: #666666; /* Темно-сірий текст */
-    cursor: not-allowed; /* Іконка забороненого доступу */
-    opacity: 0.8; /* Напівпрозорість для додаткового візуального ефекту */
-    pointer-events: none; /* Заборонити всі взаємодії */
-}
+    border: 1px solid #cbd5f5;
+    padding: 1rem;
+    font-size: 1rem;
+  }
 }
 
+.cart-page__loading {
+  text-align: center;
+  padding: 2rem;
+  color: #64748b;
+}
 
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 20;
+}
 
-.secondary-button {
-    width: 100%;
-    max-width: 400px;
-    padding: 10px;
-    background-color: #007bff; /* Secondary color (change as needed) */
-    color: #fff;
-    border: none;
-    font-size: 16px;
-    cursor: pointer;
-    border-radius: 12px;
-    margin: 10px auto 20px auto;/* Add spacing before the checkout button */
-  }
-  
-  .secondary-button:hover {
-    background-color: #0056b3; /* Darker shade for hover effect */
-  }
+.modal-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(15, 23, 42, 0.7);
+}
 
+.modal-image {
+  position: relative;
+  max-width: min(90vw, 900px);
+  max-height: 80vh;
+  border-radius: 12px;
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.35);
+}
 
-  .modal {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100vw;
-    height: 100vh;
-    background-color: rgba(0, 0, 0, 0.8);
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    z-index: 1000;
+@media (max-width: 992px) {
+  .cart-layout {
+    grid-template-columns: 1fr;
   }
-  
-  .modal-overlay {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background: transparent;
-  }
-  
-  .modal-image {
-    max-width: 80%;
-    max-height: 80%;
-    border-radius: 10px;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.5);
-  }
-
-  .error-message {
-    color: red;
-    font-size: 0.9em;
-    margin-top: 10px;
-  }
+}

--- a/src/Calendary.Ng/src/app/pages/cart/cart.component.spec.ts
+++ b/src/Calendary.Ng/src/app/pages/cart/cart.component.spec.ts
@@ -1,6 +1,23 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
 import { CartComponent } from './cart.component';
+import { CartStore } from '../../store/cart.store';
+import { OrderService } from '../../../services/order.service';
+
+class CartStoreStub {
+  order$ = of(null);
+  loading$ = of(false);
+  refreshCart() {
+    return of(null);
+  }
+  updateItemQuantity() {
+    return of(void 0);
+  }
+  removeItem() {
+    return of(void 0);
+  }
+}
 
 describe('CartComponent', () => {
   let component: CartComponent;
@@ -8,7 +25,11 @@ describe('CartComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [CartComponent]
+      imports: [CartComponent, RouterTestingModule],
+      providers: [
+        { provide: CartStore, useClass: CartStoreStub },
+        { provide: OrderService, useValue: { updateComment: () => of({}) } },
+      ],
     })
     .compileComponents();
 

--- a/src/Calendary.Ng/src/app/pages/cart/cart.component.ts
+++ b/src/Calendary.Ng/src/app/pages/cart/cart.component.ts
@@ -1,161 +1,146 @@
-import { Component, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { DeliveryComponent } from '../../components/delivery/delivery.component';
-import { CartService } from '../../../services/cart.service';
-import { PaymentService } from '../../../services/payment.service';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { CartItemComponent } from '../../components/cart/cart-item/cart-item.component';
+import { CartSummaryComponent } from '../../components/cart/cart-summary/cart-summary.component';
+import { EmptyCartComponent } from '../../components/cart/empty-cart/empty-cart.component';
 import { Order } from '../../../models/order';
 import { OrderItem } from '../../../models/order-item';
-import { RouterModule } from '@angular/router';
-import { MatDialog } from '@angular/material/dialog';
-import { ConfirmationModalComponent } from '../../components/confirmation-modal/confirmation-modal.component';
-import { OrderSummaryModalComponent } from '../../components/order-summary-modal/order-summary-modal.component';
-import { SummaryOrder } from '../../../models/summary-order';
-import { PaymentRedirect } from '../../../models/payment-redirect';
 import { OrderService } from '../../../services/order.service';
+import { CartStore } from '../../store/cart.store';
+
 @Component({
     standalone: true,
     selector: 'app-cart',
-    imports: [CommonModule, FormsModule, ReactiveFormsModule,
-        DeliveryComponent, RouterModule],
+    imports: [CommonModule, FormsModule, RouterModule, CartItemComponent, CartSummaryComponent, EmptyCartComponent],
     templateUrl: './cart.component.html',
     styleUrl: './cart.component.scss'
 })
-export class CartComponent implements OnInit {
+export class CartComponent implements OnInit, OnDestroy {
 
   order: Order | null = null;
-  delivery: any = {};
   previewImage: string | null = null;
-  
+  commentValue = '';
+  isLoading = false;
+  loadError: string | null = null;
+  updatingItemId: number | null = null;
+  removingItemId: number | null = null;
+
+  private subscriptions = new Subscription();
+
   constructor(
-    private cartService: CartService, 
-    private paymentService: PaymentService,
-    private orderService: OrderService,
-    public dialog: MatDialog // Додаємо MatDialog для роботи з модальними вікнами
+    private readonly cartStore: CartStore,
+    private readonly orderService: OrderService,
+    private readonly router: Router
   ) {}
 
   ngOnInit() {
-    this.getCart();
-  }
-
-  getCart() {
-    this.cartService.getCart().subscribe(order => {
+    this.subscriptions.add(this.cartStore.order$.subscribe((order) => {
       this.order = order;
+      this.commentValue = order?.comment ?? '';
+    }));
+
+    this.subscriptions.add(this.cartStore.loading$.subscribe((loading) => {
+      this.isLoading = loading;
+    }));
+
+    this.refreshCart();
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.unsubscribe();
+  }
+
+  refreshCart(): void {
+    this.loadError = null;
+    this.cartStore.refreshCart().subscribe({
+      error: () => {
+        this.loadError = 'Не вдалося завантажити кошик. Спробуйте ще раз.';
+      },
     });
   }
 
-  calculateTotal(): number {
-    if (!this.order) 
+  get subtotal(): number {
+    if (!this.order) {
       return 0;
-
-    return this.order.items.reduce((total, item) => total + (item.price * item.quantity), 0);
+    }
+    return this.order.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
   }
 
-  removeItem(itemId: number) {
-    if (!this.order) 
+  get totalItems(): number {
+    if (!this.order) {
+      return 0;
+    }
+    return this.order.items.reduce((sum, item) => sum + item.quantity, 0);
+  }
+
+  onQuantityChange(item: OrderItem, quantity: number): void {
+    if (quantity <= 0 || quantity === item.quantity) {
       return;
-
-    this.cartService.deleteItem(itemId).subscribe({
-      next: () => {
-        this.getCart();
-      }
-    });
-  }
-
-  onUpdateItem(item: OrderItem) {
-    this.cartService.updateItem(item).subscribe({
-      next: () => {
-        this.getCart();
-      }
-    });
-  }
-
-  updateDelivery(deliveryInfo: any) {
-    this.delivery = deliveryInfo;
-  }
-
-
-  hasIncompleteCalendars(): boolean {
-    if (!this.order) 
-      return false;
-    return this.order.items.some(item => !item.calendar?.previewPath);
-  }
-  
-  proceedToPayment() {
-
-    this.cartService.summary().subscribe({
-      next: (summary) => {
-        var { user } = summary;
-
-        if (!user.isEmailConfirmed && !user.isPhoneNumberConfirmed)
-        {
-          this.showConfirmationWarning();
-        } else {
-          this.showOrderSummary(summary);
-        }
-      },
+    }
+    this.updatingItemId = item.id;
+    this.cartStore.updateItemQuantity(item.id, quantity).subscribe({
+      next: () => (this.updatingItemId = null),
       error: (error) => {
-        console.error('Failed to load order summary:', error);
-      }
-    });
-  }
-
-  showOrderSummary(order: SummaryOrder) {
-    const dialogRef = this.dialog.open(OrderSummaryModalComponent, {
-      width: '600px',
-      data: order
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-      if (result === 'confirm') {
-        this.confirmPayment(); // Метод для підтвердження та переходу до оплати
-      }
-    });
-  }
-
-  // Метод для відображення модального вікна попередження
-  showConfirmationWarning() {
-    this.dialog.open(ConfirmationModalComponent, {
-      width: '400px'
-    });
-  }
-
-  confirmPayment() {
-    this.paymentService.getPay().subscribe({
-      next: (redirect) => {
-        this.redirectToPayment(redirect);
+        console.error('Failed to update item quantity', error);
+        this.updatingItemId = null;
       },
-      error: (error) => {
-        console.error('Failed to get payment redirect:', error);
-      }
     });
   }
-  
-  redirectToPayment(redirect: PaymentRedirect) {
-    window.location.href = redirect.paymentPage;
+
+  onRemoveItem(item: OrderItem): void {
+    this.removingItemId = item.id;
+    this.cartStore.removeItem(item.id).subscribe({
+      next: () => (this.removingItemId = null),
+      error: (error) => {
+        console.error('Failed to remove cart item', error);
+        this.removingItemId = null;
+      },
+    });
   }
 
+  goToCheckout(): void {
+    this.router.navigate(['/checkout']);
+  }
 
-  // Відкриття прев'ю
+  continueShopping(): void {
+    this.router.navigate(['/catalog']);
+  }
+
+  hasItems(): boolean {
+    return !!this.order && this.order.items.length > 0;
+  }
+
   openPreview(imagePath: string | null | undefined): void {
     if (imagePath) {
       this.previewImage = imagePath;
     }
   }
 
-  // Закриття прев'ю
   closePreview(): void {
     this.previewImage = null;
   }
 
-   // Оновлення коментаря
-   onCommentChange(): void {
-    if (this.order) 
-      {
-      this.orderService.updateComment(this.order!).subscribe({
-        next: () => console.log('Коментар збережено'),
-        error: (err) => console.error('Помилка при збереженні коментаря', err)
-      });
+  onCommentChange(): void {
+    if (!this.order) {
+      return;
     }
+    if (this.commentValue === (this.order.comment ?? '')) {
+      return;
+    }
+    this.orderService.updateComment(this.order.id, this.commentValue).subscribe({
+      next: () => {
+        if (this.order) {
+          this.order.comment = this.commentValue;
+        }
+      },
+      error: (err) => console.error('Помилка при збереженні коментаря', err),
+    });
+  }
+
+  trackByItem(_: number, item: OrderItem): number {
+    return item.id;
   }
 }

--- a/src/Calendary.Ng/src/app/pages/checkout/checkout.component.html
+++ b/src/Calendary.Ng/src/app/pages/checkout/checkout.component.html
@@ -1,0 +1,37 @@
+<section class="checkout-page">
+  <header>
+    <p class="eyebrow">Етап 2 з 2</p>
+    <h1>Оформлення замовлення</h1>
+    <p>Вкажіть контактні дані та спосіб доставки, щоб перейти до оплати.</p>
+  </header>
+
+  <div *ngIf="errorMessage" class="checkout-error">{{ errorMessage }}</div>
+
+  <ng-container *ngIf="order?.items.length; else empty">
+    <div class="checkout-layout">
+      <div class="checkout-forms">
+        <app-contact-form
+          [form]="contactForm"
+          [isEmailConfirmed]="isEmailConfirmed"
+          [isPhoneConfirmed]="isPhoneConfirmed"
+          [isSubmitting]="isSubmitting"
+          (emailVerification)="requestEmailVerification()"
+          (phoneVerification)="requestPhoneVerification()"
+        ></app-contact-form>
+
+        <app-delivery-form [form]="deliveryForm"></app-delivery-form>
+      </div>
+
+      <app-order-summary
+        [order]="order"
+        [isSubmitting]="isSubmitting"
+        (confirm)="onSubmit()"
+        (backToCart)="backToCart()"
+      ></app-order-summary>
+    </div>
+  </ng-container>
+
+  <ng-template #empty>
+    <app-empty-cart title="Кошик порожній" actionLabel="Повернутися до каталогу" actionLink="/catalog"></app-empty-cart>
+  </ng-template>
+</section>

--- a/src/Calendary.Ng/src/app/pages/checkout/checkout.component.scss
+++ b/src/Calendary.Ng/src/app/pages/checkout/checkout.component.scss
@@ -1,0 +1,40 @@
+.checkout-page {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: #94a3b8;
+}
+
+.checkout-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 360px;
+  gap: 2rem;
+}
+
+.checkout-forms {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.checkout-error {
+  padding: 1rem;
+  background: #fee2e2;
+  border-radius: 12px;
+  color: #b91c1c;
+}
+
+@media (max-width: 1024px) {
+  .checkout-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/Calendary.Ng/src/app/pages/checkout/checkout.component.ts
+++ b/src/Calendary.Ng/src/app/pages/checkout/checkout.component.ts
@@ -1,0 +1,314 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Router, RouterModule } from '@angular/router';
+import { MatDialog } from '@angular/material/dialog';
+import { forkJoin, Subject, takeUntil } from 'rxjs';
+import { ContactFormComponent } from '../../components/checkout/contact-form/contact-form.component';
+import { DeliveryFormComponent } from '../../components/checkout/delivery-form/delivery-form.component';
+import { OrderSummaryComponent } from '../../components/checkout/order-summary/order-summary.component';
+import { EmptyCartComponent } from '../../components/cart/empty-cart/empty-cart.component';
+import { CartStore } from '../../store/cart.store';
+import { Order } from '../../../models/order';
+import { UserInfo } from '../../../models/user';
+import { DeliveryInfo } from '../../../models/delivery-info';
+import { NovaPostItem } from '../../../models/nova-post-item';
+import { CartService } from '../../../services/cart.service';
+import { UserService } from '../../../services/user.service';
+import { VerificationService } from '../../../services/verification.service';
+import { VerificationDialogComponent } from '../../components/verification-dialog/verification-dialog.component';
+import { OrderSummaryModalComponent } from '../../components/order-summary-modal/order-summary-modal.component';
+import { ConfirmationModalComponent } from '../../components/confirmation-modal/confirmation-modal.component';
+import { PaymentService } from '../../../services/payment.service';
+
+@Component({
+    standalone: true,
+    selector: 'app-checkout',
+    imports: [CommonModule, ReactiveFormsModule, RouterModule, ContactFormComponent, DeliveryFormComponent, OrderSummaryComponent, EmptyCartComponent],
+    templateUrl: './checkout.component.html',
+    styleUrl: './checkout.component.scss'
+})
+export class CheckoutComponent implements OnInit, OnDestroy {
+  contactForm: FormGroup;
+  deliveryForm: FormGroup;
+
+  order: Order | null = null;
+  isSubmitting = false;
+  isLoadingCart = true;
+  errorMessage: string | null = null;
+  isEmailConfirmed = false;
+  isPhoneConfirmed = false;
+
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private readonly fb: FormBuilder,
+    private readonly cartStore: CartStore,
+    private readonly cartService: CartService,
+    private readonly userService: UserService,
+    private readonly verificationService: VerificationService,
+    private readonly paymentService: PaymentService,
+    private readonly dialog: MatDialog,
+    private readonly router: Router
+  ) {
+    this.contactForm = this.fb.group({
+      firstName: ['', [Validators.required, Validators.minLength(2)]],
+      lastName: ['', [Validators.required, Validators.minLength(2)]],
+      email: ['', [Validators.required, Validators.email]],
+      phone: ['', [Validators.required, Validators.pattern(/^\+?380\d{9}$/)]],
+    });
+
+    this.deliveryForm = this.fb.group({
+      method: ['nova-poshta-warehouse', Validators.required],
+      city: ['', Validators.required],
+      cityRef: [''],
+      warehouse: ['', Validators.required],
+      warehouseRef: [''],
+      address: this.fb.group({
+        street: [''],
+        building: [''],
+        apartment: [''],
+      }),
+    });
+  }
+
+  ngOnInit(): void {
+    this.cartStore.order$.pipe(takeUntil(this.destroy$)).subscribe((order) => {
+      this.order = order;
+    });
+
+    this.cartStore.loading$.pipe(takeUntil(this.destroy$)).subscribe((loading) => {
+      this.isLoadingCart = loading;
+    });
+
+    this.cartStore.refreshCart().subscribe({
+      error: () => {
+        this.isLoadingCart = false;
+        this.errorMessage = 'Не вдалося завантажити кошик.';
+      },
+    });
+
+    this.loadUserInfo();
+    this.loadDeliveryInfo();
+    this.setupDeliveryValidators();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  private loadUserInfo(): void {
+    this.userService.getInfo().subscribe((info) => {
+      if (!info) {
+        return;
+      }
+      const [firstName = '', ...rest] = (info.userName || '').split(' ');
+      const lastName = rest.join(' ');
+      this.contactForm.patchValue({
+        firstName: firstName || info.userName,
+        lastName: lastName || '',
+        email: info.email,
+        phone: info.phoneNumber,
+      });
+      this.isEmailConfirmed = info.isEmailConfirmed;
+      this.isPhoneConfirmed = info.isPhoneNumberConfirmed;
+    });
+  }
+
+  private loadDeliveryInfo(): void {
+    this.cartService.getDeliveryInfo().subscribe((delivery) => {
+      if (!delivery) {
+        return;
+      }
+      const method = this.detectDeliveryMethod(delivery.postOffice);
+      this.deliveryForm.patchValue({
+        method,
+        city: delivery.city.description,
+        cityRef: delivery.city.ref,
+        warehouse: delivery.postOffice.description,
+        warehouseRef: delivery.postOffice.ref,
+      });
+    });
+  }
+
+  private detectDeliveryMethod(postOffice: NovaPostItem): string {
+    if (!postOffice?.description) {
+      return 'nova-poshta-warehouse';
+    }
+    const description = postOffice.description.toLowerCase();
+    if (description.includes('кур')) {
+      return 'nova-poshta-courier';
+    }
+    if (description.includes('самовивіз')) {
+      return 'pickup';
+    }
+    return 'nova-poshta-warehouse';
+  }
+
+  private setupDeliveryValidators(): void {
+    this.applyDeliveryValidators(this.deliveryForm.get('method')?.value);
+    this.deliveryForm
+      .get('method')
+      ?.valueChanges.pipe(takeUntil(this.destroy$))
+      .subscribe((method) => this.applyDeliveryValidators(method));
+  }
+
+  private applyDeliveryValidators(method: string): void {
+    const warehouseControl = this.deliveryForm.get('warehouse');
+    const addressGroup = this.deliveryForm.get('address') as FormGroup;
+    const street = addressGroup.get('street');
+    const building = addressGroup.get('building');
+
+    if (method === 'nova-poshta-warehouse') {
+      warehouseControl?.setValidators([Validators.required]);
+      street?.clearValidators();
+      building?.clearValidators();
+    } else if (method === 'nova-poshta-courier') {
+      warehouseControl?.clearValidators();
+      street?.setValidators([Validators.required]);
+      building?.setValidators([Validators.required]);
+    } else {
+      warehouseControl?.clearValidators();
+      street?.clearValidators();
+      building?.clearValidators();
+    }
+
+    warehouseControl?.updateValueAndValidity({ emitEvent: false });
+    street?.updateValueAndValidity({ emitEvent: false });
+    building?.updateValueAndValidity({ emitEvent: false });
+  }
+
+  onSubmit(): void {
+    if (!this.order) {
+      return;
+    }
+    if (this.contactForm.invalid || this.deliveryForm.invalid) {
+      this.contactForm.markAllAsTouched();
+      this.deliveryForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting = true;
+    this.errorMessage = null;
+
+    const contactPayload = this.buildContactPayload();
+    const deliveryPayload = this.buildDeliveryPayload();
+
+    forkJoin([
+      this.userService.updateInfo(contactPayload),
+      this.cartService.updateDeliveryInfo(deliveryPayload),
+    ])
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => this.showOrderSummary(),
+        error: (error) => {
+          console.error(error);
+          this.errorMessage = 'Не вдалося зберегти дані. Спробуйте ще раз.';
+          this.isSubmitting = false;
+        },
+      });
+  }
+
+  private buildContactPayload(): UserInfo {
+    const payload = new UserInfo();
+    payload.userName = `${this.contactForm.value.firstName} ${this.contactForm.value.lastName}`.trim();
+    payload.email = this.contactForm.value.email;
+    payload.phoneNumber = this.contactForm.value.phone;
+    return payload;
+  }
+
+  private buildDeliveryPayload(): DeliveryInfo {
+    const payload = new DeliveryInfo();
+    payload.city.description = this.deliveryForm.value.city;
+    payload.city.ref = this.deliveryForm.value.cityRef;
+
+    if (this.deliveryForm.value.method === 'nova-poshta-courier') {
+      const address = this.deliveryForm.value.address;
+      payload.postOffice.description = `Кур'єр: ${address.street || ''} ${address.building || ''}`.trim();
+    } else if (this.deliveryForm.value.method === 'pickup') {
+      payload.postOffice.description = 'Самовивіз з шоуруму Calendary';
+    } else {
+      payload.postOffice.description = this.deliveryForm.value.warehouse;
+      payload.postOffice.ref = this.deliveryForm.value.warehouseRef;
+    }
+    return payload;
+  }
+
+  private showOrderSummary(): void {
+    this.cartService.summary().subscribe({
+      next: (summary) => {
+        if (!summary.user.isEmailConfirmed || !summary.user.isPhoneNumberConfirmed) {
+          this.dialog.open(ConfirmationModalComponent, { width: '400px' });
+          this.isSubmitting = false;
+          return;
+        }
+        const dialogRef = this.dialog.open(OrderSummaryModalComponent, {
+          width: '600px',
+          data: summary,
+        });
+        dialogRef.afterClosed().subscribe((result) => {
+          if (result === 'confirm') {
+            this.redirectToPayment();
+          } else {
+            this.isSubmitting = false;
+          }
+        });
+      },
+      error: (error) => {
+        console.error('Failed to load summary', error);
+        this.errorMessage = 'Не вдалося завантажити підсумок замовлення.';
+        this.isSubmitting = false;
+      },
+    });
+  }
+
+  private redirectToPayment(): void {
+    this.paymentService.getPay().subscribe({
+      next: (redirect) => {
+        window.location.href = redirect.paymentPage;
+      },
+      error: (error) => {
+        console.error('Failed to redirect to payment', error);
+        this.isSubmitting = false;
+      },
+    });
+  }
+
+  requestEmailVerification(): void {
+    if (this.contactForm.get('email')?.invalid) {
+      this.contactForm.get('email')?.markAsTouched();
+      return;
+    }
+    this.verificationService.sendEmailVerification().subscribe(() => {
+      this.openVerificationModal('email');
+    });
+  }
+
+  requestPhoneVerification(): void {
+    if (this.contactForm.get('phone')?.invalid) {
+      this.contactForm.get('phone')?.markAsTouched();
+      return;
+    }
+    this.verificationService.sendPhoneVerification().subscribe(() => {
+      this.openVerificationModal('phone');
+    });
+  }
+
+  private openVerificationModal(type: 'email' | 'phone'): void {
+    const dialogRef = this.dialog.open(VerificationDialogComponent, {
+      width: '400px',
+      data: { type },
+    });
+
+    dialogRef.afterClosed().subscribe((result) => {
+      if (result) {
+        this.loadUserInfo();
+      }
+    });
+  }
+
+  backToCart(): void {
+    this.router.navigate(['/cart']);
+  }
+}

--- a/src/Calendary.Ng/src/app/store/cart.store.ts
+++ b/src/Calendary.Ng/src/app/store/cart.store.ts
@@ -1,0 +1,111 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable, catchError, finalize, map, of, tap, throwError } from 'rxjs';
+import { Order } from '../../models/order';
+import { OrderItem } from '../../models/order-item';
+import { CartService } from '../../services/cart.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class CartStore {
+  private readonly orderSubject = new BehaviorSubject<Order | null>(null);
+  readonly order$ = this.orderSubject.asObservable();
+
+  private readonly loadingSubject = new BehaviorSubject<boolean>(false);
+  readonly loading$ = this.loadingSubject.asObservable();
+
+  private readonly totalItemsSubject = new BehaviorSubject<number>(0);
+  readonly totalItems$ = this.totalItemsSubject.asObservable();
+
+  constructor(private readonly cartService: CartService) {}
+
+  refreshCart(): Observable<Order | null> {
+    this.loadingSubject.next(true);
+    return this.cartService.getCart().pipe(
+      tap((order) => this.setOrder(order)),
+      map((order) => order),
+      catchError((error: HttpErrorResponse) => {
+        if (error.status === 404) {
+          this.setOrder(null);
+          return of(null);
+        }
+        return throwError(() => error);
+      }),
+      finalize(() => this.loadingSubject.next(false))
+    );
+  }
+
+  syncCartCount(): Observable<number> {
+    return this.cartService.itemsInCart().pipe(
+      tap((count) => this.totalItemsSubject.next(count))
+    );
+  }
+
+  updateItemQuantity(itemId: number, quantity: number): Observable<void> {
+    const currentOrder = this.orderSubject.value;
+    if (!currentOrder) {
+      return throwError(() => new Error('Cart is empty'));
+    }
+    const targetItem = currentOrder.items.find((item) => item.id === itemId);
+    if (!targetItem) {
+      return throwError(() => new Error('Item not found'));
+    }
+
+    const payload: OrderItem = { ...targetItem, quantity };
+
+    return this.cartService.updateItem(payload).pipe(
+      tap(() => {
+        const updatedOrder: Order = {
+          ...currentOrder,
+          items: currentOrder.items.map((item) =>
+            item.id === itemId ? { ...item, quantity } : item
+          ),
+        };
+        this.setOrder(updatedOrder.items.length ? updatedOrder : null);
+      }),
+      map(() => void 0)
+    );
+  }
+
+  removeItem(itemId: number): Observable<void> {
+    return this.cartService.deleteItem(itemId).pipe(
+      tap(() => {
+        const currentOrder = this.orderSubject.value;
+        if (!currentOrder) {
+          return;
+        }
+        const remainingItems = currentOrder.items.filter((item) => item.id !== itemId);
+        const nextOrder = remainingItems.length
+          ? { ...currentOrder, items: remainingItems }
+          : null;
+        this.setOrder(nextOrder);
+      }),
+      map(() => void 0)
+    );
+  }
+
+  getTotalPrice(): number {
+    const order = this.orderSubject.value;
+    if (!order) {
+      return 0;
+    }
+    return order.items.reduce((sum, item) => sum + item.price * item.quantity, 0);
+  }
+
+  getTotalItems(): number {
+    return this.totalItemsSubject.value;
+  }
+
+  getOrderSnapshot(): Order | null {
+    return this.orderSubject.value;
+  }
+
+  private setOrder(order: Order | null): void {
+    this.orderSubject.next(order);
+    const totalItems = order
+      ? order.items.reduce((sum, item) => sum + item.quantity, 0)
+      : 0;
+    this.totalItemsSubject.next(totalItems);
+  }
+}

--- a/src/Calendary.Ng/src/services/order.service.ts
+++ b/src/Calendary.Ng/src/services/order.service.ts
@@ -3,7 +3,6 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { SummaryOrder } from '../models/summary-order';
 import { OrderResult } from '../models/results/order.result';
-import { Order } from '../models/order';
 
 @Injectable({
   providedIn: 'root'
@@ -21,7 +20,7 @@ export class OrderService {
     return this.http.get<OrderResult>(`${this.apiUrl}/my?page=${page}`);
   }
 
-  updateComment(order: Order): Observable<Order> {
-    return this.http.put<Order>(`${this.apiUrl}/comment`, order);
+  updateComment(orderId: number, comment: string | null): Observable<void> {
+    return this.http.put<void>(`${this.apiUrl}/comment`, { id: orderId, comment });
   }
 }


### PR DESCRIPTION
## Summary
- refactor the cart page around a central CartStore, modular item/summary/empty components, and a refreshed layout with comment persistence
- add a guarded checkout route with contact and delivery forms, order summary, and MonoBank-ready confirmation logic plus a live cart badge in the header
- align the order service comment update call with the lightweight DTO expected by the API

## Testing
- `npm run lint` *(fails: ng command is unavailable in this container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a2b060604832b9e364a9103633dde)