### PR TITLE
Rewrite user registration and editor flow

### DIFF
--- a/src/Calendary.Api/Controllers/UserPhotoController.cs
+++ b/src/Calendary.Api/Controllers/UserPhotoController.cs
@@ -1,0 +1,192 @@
+using Calendary.Core.Providers;
+using Calendary.Core.Services;
+using Calendary.Model;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Calendary.Api.Controllers;
+
+[Authorize]
+[ApiController]
+[Route("api/user-photo")]
+public class UserPhotoController : BaseUserController
+{
+    private readonly string _uploadDirectory = "uploads/user-photos";
+    private readonly IPathProvider _pathProvider;
+    private readonly IUserPhotoService _userPhotoService;
+
+    public UserPhotoController(
+        IPathProvider pathProvider,
+        IUserService userService,
+        IUserPhotoService userPhotoService) : base(userService)
+    {
+        _pathProvider = pathProvider;
+        _userPhotoService = userPhotoService;
+
+        var realUploadDirectory = _pathProvider.MapPath(_uploadDirectory);
+        if (!Directory.Exists(realUploadDirectory))
+        {
+            Directory.CreateDirectory(realUploadDirectory);
+        }
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetUserPhotos()
+    {
+        var user = await CurrentUser.Value;
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var photos = await _userPhotoService.GetByUserIdAsync(user.Id);
+        return Ok(photos);
+    }
+
+    [HttpGet("{id:int}")]
+    public async Task<IActionResult> GetUserPhoto(int id)
+    {
+        var user = await CurrentUser.Value;
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var photo = await _userPhotoService.GetByIdAndUserIdAsync(id, user.Id);
+        if (photo is null)
+        {
+            return NotFound($"Photo with ID {id} not found.");
+        }
+
+        return Ok(photo);
+    }
+
+    [HttpPost]
+    public async Task<IActionResult> UploadPhoto([FromForm] IFormFile file, [FromForm] string? caption)
+    {
+        var user = await CurrentUser.Value;
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        if (file == null || file.Length == 0)
+        {
+            return BadRequest("No file uploaded.");
+        }
+
+        // Validate file type
+        var allowedExtensions = new[] { ".jpg", ".jpeg", ".png", ".gif", ".webp" };
+        var fileExtension = Path.GetExtension(file.FileName).ToLowerInvariant();
+        if (!allowedExtensions.Contains(fileExtension))
+        {
+            return BadRequest("Invalid file type. Only image files are allowed.");
+        }
+
+        // Validate file size (max 10MB)
+        const long maxFileSize = 10 * 1024 * 1024; // 10MB
+        if (file.Length > maxFileSize)
+        {
+            return BadRequest("File size exceeds the maximum allowed size of 10MB.");
+        }
+
+        var uploadDirectory = Path.Combine(_uploadDirectory, user.Id.ToString());
+        var filePath = await SaveFileAsync(file, uploadDirectory);
+
+        var photo = new UserPhoto
+        {
+            UserId = user.Id,
+            ImageUrl = filePath,
+            Caption = caption,
+            OriginalFileName = file.FileName,
+            FileSize = file.Length,
+            CreatedAt = DateTime.UtcNow
+        };
+
+        await _userPhotoService.CreateAsync(photo);
+
+        return Ok(new { Message = "File uploaded successfully.", Photo = photo });
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> UpdatePhoto(int id, [FromBody] UpdatePhotoRequest request)
+    {
+        var user = await CurrentUser.Value;
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var photo = await _userPhotoService.GetByIdAndUserIdAsync(id, user.Id);
+        if (photo is null)
+        {
+            return NotFound($"Photo with ID {id} not found.");
+        }
+
+        photo.Caption = request.Caption;
+        await _userPhotoService.UpdateAsync(photo);
+
+        return Ok(new { Message = "Photo updated successfully.", Photo = photo });
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> DeletePhoto(int id)
+    {
+        var user = await CurrentUser.Value;
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+
+        var photo = await _userPhotoService.GetByIdAndUserIdAsync(id, user.Id);
+        if (photo is null)
+        {
+            return NotFound($"Photo with ID {id} not found.");
+        }
+
+        // Soft delete
+        await _userPhotoService.SoftDeleteAsync(id, user.Id);
+
+        // Optionally delete the physical file
+        try
+        {
+            var realFilePath = _pathProvider.MapPath(photo.ImageUrl);
+            if (System.IO.File.Exists(realFilePath))
+            {
+                System.IO.File.Delete(realFilePath);
+            }
+        }
+        catch (Exception ex)
+        {
+            // Log error but don't fail the request
+            Console.WriteLine($"Error deleting file: {ex.Message}");
+        }
+
+        return Ok(new { Message = "Photo deleted successfully." });
+    }
+
+    private async Task<string> SaveFileAsync(IFormFile file, string uploadDirectory)
+    {
+        var fileName = $"{Guid.NewGuid()}_{Path.GetFileName(file.FileName)}";
+        var filePath = Path.Combine(uploadDirectory, fileName);
+        var realFilePath = _pathProvider.MapPath(filePath);
+
+        var directory = Path.GetDirectoryName(realFilePath);
+        if (!string.IsNullOrEmpty(directory) && !Directory.Exists(directory))
+        {
+            Directory.CreateDirectory(directory);
+        }
+
+        using (var stream = new FileStream(realFilePath, FileMode.Create))
+        {
+            await file.CopyToAsync(stream);
+        }
+
+        return filePath.Replace("\\", "/");
+    }
+}
+
+public class UpdatePhotoRequest
+{
+    public string? Caption { get; set; }
+}

--- a/src/Calendary.Core/DependencyRegistration.cs
+++ b/src/Calendary.Core/DependencyRegistration.cs
@@ -38,6 +38,7 @@ public static class DependencyRegistration
         services.AddScoped<IPromptService, PromptService>();
         services.AddHttpClient<IPromptEnhancerService, PromptEnhancerService>();
         services.AddScoped<IPhotoService, PhotoService>();
+        services.AddScoped<IUserPhotoService, UserPhotoService>();
         services.AddScoped<IFluxModelService, FluxModelService>();
         services.AddScoped<ITrainingService, TrainingService>();
         services.AddScoped<IJobService, JobService>();

--- a/src/Calendary.Core/Services/UserPhotoService.cs
+++ b/src/Calendary.Core/Services/UserPhotoService.cs
@@ -1,0 +1,59 @@
+using Calendary.Model;
+using Calendary.Repos.Repositories;
+
+namespace Calendary.Core.Services;
+
+public interface IUserPhotoService
+{
+    Task<IReadOnlyCollection<UserPhoto>> GetByUserIdAsync(int userId, bool includeDeleted = false);
+    Task<UserPhoto?> GetByIdAsync(int id);
+    Task<UserPhoto?> GetByIdAndUserIdAsync(int id, int userId);
+    Task<int> GetCountByUserIdAsync(int userId);
+    Task<UserPhoto> CreateAsync(UserPhoto photo);
+    Task<UserPhoto> UpdateAsync(UserPhoto photo);
+    Task DeleteAsync(int id, int userId);
+    Task SoftDeleteAsync(int id, int userId);
+}
+
+public class UserPhotoService : IUserPhotoService
+{
+    private readonly IUserPhotoRepository _photoRepository;
+
+    public UserPhotoService(IUserPhotoRepository photoRepository)
+    {
+        _photoRepository = photoRepository;
+    }
+
+    public Task<IReadOnlyCollection<UserPhoto>> GetByUserIdAsync(int userId, bool includeDeleted = false)
+        => _photoRepository.GetByUserIdAsync(userId, includeDeleted);
+
+    public Task<UserPhoto?> GetByIdAsync(int id)
+        => _photoRepository.GetByIdAsync(id);
+
+    public Task<UserPhoto?> GetByIdAndUserIdAsync(int id, int userId)
+        => _photoRepository.GetByIdAndUserIdAsync(id, userId);
+
+    public Task<int> GetCountByUserIdAsync(int userId)
+        => _photoRepository.GetCountByUserIdAsync(userId);
+
+    public async Task<UserPhoto> CreateAsync(UserPhoto photo)
+    {
+        photo.CreatedAt = DateTime.UtcNow;
+        photo.IsDeleted = false;
+        await _photoRepository.AddAsync(photo);
+        return photo;
+    }
+
+    public async Task<UserPhoto> UpdateAsync(UserPhoto photo)
+    {
+        photo.UpdatedAt = DateTime.UtcNow;
+        await _photoRepository.UpdateAsync(photo);
+        return photo;
+    }
+
+    public Task DeleteAsync(int id, int userId)
+        => _photoRepository.DeleteAsync(id);
+
+    public Task SoftDeleteAsync(int id, int userId)
+        => _photoRepository.SoftDeleteAsync(id, userId);
+}

--- a/src/Calendary.Model/UserPhoto.cs
+++ b/src/Calendary.Model/UserPhoto.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Calendary.Model;
+
+public class UserPhoto
+{
+    public int Id { get; set; }
+
+    public int UserId { get; set; }
+
+    public string ImageUrl { get; set; } = string.Empty;
+
+    public string? Caption { get; set; }
+
+    public string? OriginalFileName { get; set; }
+
+    public long FileSize { get; set; }
+
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    public DateTime? UpdatedAt { get; set; }
+
+    public bool IsDeleted { get; set; } = false;
+
+    // Navigation properties
+    [JsonIgnore]
+    public User User { get; set; } = null!;
+}

--- a/src/Calendary.Ng/src/app/pages/login/login.component.ts
+++ b/src/Calendary.Ng/src/app/pages/login/login.component.ts
@@ -60,7 +60,7 @@ export class LoginComponent {
               window.location.reload();
             });
           } else {
-            this.router.navigate(['/']).then(() => {
+            this.router.navigate(['/editor']).then(() => {
               window.location.reload();
             });
           }

--- a/src/Calendary.Ng/src/app/pages/register/register.component.ts
+++ b/src/Calendary.Ng/src/app/pages/register/register.component.ts
@@ -102,7 +102,7 @@ export class RegisterComponent {
     dialogRef.afterClosed().subscribe((result) => {
 
       if (result) {
-        this.router.navigate(['/master']).then(() => {
+        this.router.navigate(['/editor']).then(() => {
           window.location.reload();
         });
       }

--- a/src/Calendary.Ng/src/models/user-photo.ts
+++ b/src/Calendary.Ng/src/models/user-photo.ts
@@ -1,0 +1,16 @@
+export interface UserPhoto {
+  id: number;
+  userId: number;
+  imageUrl: string;
+  caption?: string;
+  originalFileName?: string;
+  fileSize: number;
+  createdAt: Date;
+  updatedAt?: Date;
+  isDeleted: boolean;
+}
+
+export interface UserPhotoUpload {
+  file: File;
+  caption?: string;
+}

--- a/src/Calendary.Ng/src/services/user-photo.service.ts
+++ b/src/Calendary.Ng/src/services/user-photo.service.ts
@@ -1,0 +1,52 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpEvent } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { UserPhoto } from '../models/user-photo';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class UserPhotoService {
+  private apiUrl = '/api/user-photo';
+
+  constructor(private http: HttpClient) {}
+
+  getUserPhotos(): Observable<UserPhoto[]> {
+    return this.http.get<UserPhoto[]>(this.apiUrl);
+  }
+
+  getUserPhoto(id: number): Observable<UserPhoto> {
+    return this.http.get<UserPhoto>(`${this.apiUrl}/${id}`);
+  }
+
+  uploadPhoto(file: File, caption?: string): Observable<{ message: string; photo: UserPhoto }> {
+    const formData = new FormData();
+    formData.append('file', file);
+    if (caption) {
+      formData.append('caption', caption);
+    }
+
+    return this.http.post<{ message: string; photo: UserPhoto }>(this.apiUrl, formData);
+  }
+
+  uploadPhotoWithProgress(file: File, caption?: string): Observable<HttpEvent<{ message: string; photo: UserPhoto }>> {
+    const formData = new FormData();
+    formData.append('file', file);
+    if (caption) {
+      formData.append('caption', caption);
+    }
+
+    return this.http.post<{ message: string; photo: UserPhoto }>(this.apiUrl, formData, {
+      reportProgress: true,
+      observe: 'events'
+    });
+  }
+
+  updatePhoto(id: number, caption: string): Observable<{ message: string; photo: UserPhoto }> {
+    return this.http.put<{ message: string; photo: UserPhoto }>(`${this.apiUrl}/${id}`, { caption });
+  }
+
+  deletePhoto(id: number): Observable<{ message: string }> {
+    return this.http.delete<{ message: string }>(`${this.apiUrl}/${id}`);
+  }
+}

--- a/src/Calendary.Repos/CalendaryDbContext.cs
+++ b/src/Calendary.Repos/CalendaryDbContext.cs
@@ -45,6 +45,8 @@ public class CalendaryDbContext : DbContext, ICalendaryDbContext
 
     public DbSet<Photo> Photos { get; set; }
 
+    public DbSet<UserPhoto> UserPhotos { get; set; }
+
     public DbSet<Prompt> Prompts { get; set; }
 
     public DbSet<PromptSeed> PromptSeeds { get; set; }

--- a/src/Calendary.Repos/Configurations/UserPhotoConfiguration.cs
+++ b/src/Calendary.Repos/Configurations/UserPhotoConfiguration.cs
@@ -1,0 +1,49 @@
+using Calendary.Model;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Calendary.Repos.Configurations;
+
+public class UserPhotoConfiguration : IEntityTypeConfiguration<UserPhoto>
+{
+    public void Configure(EntityTypeBuilder<UserPhoto> builder)
+    {
+        builder.ToTable("UserPhotos");
+
+        builder.HasKey(p => p.Id);
+
+        builder.Property(p => p.ImageUrl)
+            .IsRequired()
+            .HasMaxLength(500);
+
+        builder.Property(p => p.Caption)
+            .HasMaxLength(500);
+
+        builder.Property(p => p.OriginalFileName)
+            .HasMaxLength(255);
+
+        builder.Property(p => p.FileSize)
+            .IsRequired();
+
+        builder.Property(p => p.CreatedAt)
+            .IsRequired()
+            .HasDefaultValueSql("GETUTCDATE()");
+
+        builder.Property(p => p.UpdatedAt);
+
+        builder.Property(p => p.IsDeleted)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        // Relationships
+        builder.HasOne(p => p.User)
+            .WithMany()
+            .HasForeignKey(p => p.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        // Indexes
+        builder.HasIndex(p => p.UserId);
+        builder.HasIndex(p => p.CreatedAt);
+        builder.HasIndex(p => p.IsDeleted);
+    }
+}

--- a/src/Calendary.Repos/DependencyRegistration.cs
+++ b/src/Calendary.Repos/DependencyRegistration.cs
@@ -35,6 +35,7 @@ namespace Calendary.Repos
             services.AddScoped<IJobRepository, JobRepository>();
             services.AddScoped<IJobTaskRepository, JobTaskRepository>();
             services.AddScoped<IPhotoRepository, PhotoRepository>();
+            services.AddScoped<IUserPhotoRepository, UserPhotoRepository>();
             services.AddScoped<IResetTokenRepository, ResetTokenRepository>();
             services.AddScoped<IPromptRepository, PromptRepository>();
             services.AddScoped<IPromptThemeRepository, PromptThemeRepository>();

--- a/src/Calendary.Repos/Repositories/UserPhotoRepository.cs
+++ b/src/Calendary.Repos/Repositories/UserPhotoRepository.cs
@@ -1,0 +1,99 @@
+using Calendary.Model;
+using Microsoft.EntityFrameworkCore;
+
+namespace Calendary.Repos.Repositories;
+
+public interface IUserPhotoRepository : IRepository<UserPhoto>
+{
+    Task<IReadOnlyCollection<UserPhoto>> GetByUserIdAsync(int userId, bool includeDeleted = false);
+    Task<UserPhoto?> GetByIdAndUserIdAsync(int id, int userId);
+    Task<int> GetCountByUserIdAsync(int userId);
+    Task SoftDeleteAsync(int id, int userId);
+}
+
+public class UserPhotoRepository : IUserPhotoRepository
+{
+    private readonly ICalendaryDbContext _context;
+
+    public UserPhotoRepository(ICalendaryDbContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<IEnumerable<UserPhoto>> GetAllAsync()
+    {
+        return await _context.UserPhotos
+            .Where(p => !p.IsDeleted)
+            .OrderByDescending(p => p.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<UserPhoto?> GetByIdAsync(int id)
+    {
+        return await _context.UserPhotos
+            .Where(p => p.Id == id && !p.IsDeleted)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<UserPhoto?> GetByIdAndUserIdAsync(int id, int userId)
+    {
+        return await _context.UserPhotos
+            .Where(p => p.Id == id && p.UserId == userId && !p.IsDeleted)
+            .FirstOrDefaultAsync();
+    }
+
+    public async Task<IReadOnlyCollection<UserPhoto>> GetByUserIdAsync(int userId, bool includeDeleted = false)
+    {
+        var query = _context.UserPhotos.Where(p => p.UserId == userId);
+
+        if (!includeDeleted)
+        {
+            query = query.Where(p => !p.IsDeleted);
+        }
+
+        return await query
+            .OrderByDescending(p => p.CreatedAt)
+            .ToListAsync();
+    }
+
+    public async Task<int> GetCountByUserIdAsync(int userId)
+    {
+        return await _context.UserPhotos
+            .Where(p => p.UserId == userId && !p.IsDeleted)
+            .CountAsync();
+    }
+
+    public async Task AddAsync(UserPhoto entity)
+    {
+        await _context.UserPhotos.AddAsync(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task UpdateAsync(UserPhoto entity)
+    {
+        entity.UpdatedAt = DateTime.UtcNow;
+        _context.UserPhotos.Update(entity);
+        await _context.SaveChangesAsync();
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        var entity = await _context.UserPhotos.FindAsync(id);
+        if (entity is not null)
+        {
+            _context.UserPhotos.Remove(entity);
+            await _context.SaveChangesAsync();
+        }
+    }
+
+    public async Task SoftDeleteAsync(int id, int userId)
+    {
+        var entity = await GetByIdAndUserIdAsync(id, userId);
+        if (entity is not null)
+        {
+            entity.IsDeleted = true;
+            entity.UpdatedAt = DateTime.UtcNow;
+            await UpdateAsync(entity);
+        }
+    }
+}


### PR DESCRIPTION
Backend changes:
- Add UserPhoto entity for simple photo uploads (without FluxModel)
- Add UserPhotoConfiguration for EF Core
- Add UserPhotoRepository with CRUD operations
- Add UserPhotoService for business logic
- Add UserPhotoController API endpoints (GET, POST, PUT, DELETE)
- Register UserPhoto services in DI
- Update CalendaryDbContext with UserPhotos DbSet

Frontend changes:
- Add UserPhoto model and interfaces
- Add UserPhotoService for API calls
- Redirect users to /editor after login/register instead of home/master

This lays foundation for Simple Calendar flow where users can upload photos directly without training AI model.