### PR TITLE
feat: personal dates as a 12-month grid with add-date modal

### DIFF
--- a/frontend/src/app/pages/style-dates/style-dates.component.ts
+++ b/frontend/src/app/pages/style-dates/style-dates.component.ts
@@ -27,37 +27,71 @@ import { OrderDto, StyleCategoryDto } from '../../core/models';
 
       <h2 style="font-size: 28px;">Персональні дати</h2>
       <p class="text-muted">
-        Дні народження, річниці, важливі дати. Ми надрукуємо їх синім у сітці місяця.
+        Дні народження, річниці, важливі дати. Ми надрукуємо їх синім у сітці місяця. Оберіть місяць, щоб додати дату.
       </p>
 
-      @for (date of order()?.personalDates ?? []; track date.id) {
-        <div style="display: flex; gap: 10px; align-items: center; padding: 11px 0; border-bottom: 1px solid var(--color-divider);">
-          <span class="money" style="font-size: 13px; color: var(--color-accent-700); width: 52px; flex: none;">
-            {{ pad(date.day) }}.{{ pad(date.month) }}
-          </span>
-          <span style="font-size: 13.5px; flex: 1;">{{ date.label }}</span>
-          <button class="btn btn-ghost" (click)="removeDate(date.id)">Видалити</button>
-        </div>
-      }
-
-      <div style="display: flex; gap: 10px; align-items: flex-end; margin-top: var(--space-3); flex-wrap: wrap;">
-        <div class="field" style="width: 70px;">
-          <label>День</label>
-          <input class="input" type="number" min="1" max="31" [(ngModel)]="newDay" />
-        </div>
-        <div class="field" style="width: 70px;">
-          <label>Місяць</label>
-          <input class="input" type="number" min="1" max="12" [(ngModel)]="newMonth" />
-        </div>
-        <div class="field" style="flex: 1; min-width: 180px;">
-          <label>Підпис (до 22 символів)</label>
-          <input class="input" maxlength="22" [(ngModel)]="newLabel" />
-        </div>
-        <button class="btn btn-secondary" [disabled]="!newLabel" (click)="addDate()">Додати дату</button>
+      <div class="month-grid">
+        @for (m of months; track m.number) {
+          <button
+            type="button"
+            class="month-tile"
+            [class.has-dates]="datesForMonth(m.number).length > 0"
+            (click)="openMonth(m.number)"
+          >
+            <div class="month-tile-name">{{ m.name }}</div>
+            @if (datesForMonth(m.number).length) {
+              <div class="month-tile-dates">
+                @for (date of datesForMonth(m.number); track date.id) {
+                  <span class="month-tile-date">{{ pad(date.day) }} · {{ date.label }}</span>
+                }
+              </div>
+            } @else {
+              <div class="month-tile-empty">+ Додати</div>
+            }
+          </button>
+        }
       </div>
 
-      @if (error()) {
-        <p style="color: var(--color-accent-2-700); font-size: 13px; margin-top: var(--space-3);">{{ error() }}</p>
+      @if (selectedMonth(); as month) {
+        <div class="dialog-backdrop" (click)="closeModal()">
+          <div class="dialog" (click)="$event.stopPropagation()">
+            <div class="dialog-title">{{ monthName(month) }}</div>
+
+            @if (datesForMonth(month).length) {
+              <div>
+                @for (date of datesForMonth(month); track date.id) {
+                  <div style="display: flex; gap: 10px; align-items: center; padding: 8px 0; border-bottom: 1px solid var(--color-divider);">
+                    <span class="money" style="font-size: 13px; color: var(--color-accent-700); width: 30px; flex: none;">
+                      {{ pad(date.day) }}
+                    </span>
+                    <span style="font-size: 13.5px; flex: 1;">{{ date.label }}</span>
+                    <button class="btn btn-ghost" (click)="removeDate(date.id)">Видалити</button>
+                  </div>
+                }
+              </div>
+            }
+
+            <div style="display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap;">
+              <div class="field" style="width: 70px;">
+                <label>День</label>
+                <input class="input" type="number" min="1" max="31" [(ngModel)]="newDay" />
+              </div>
+              <div class="field" style="flex: 1; min-width: 180px;">
+                <label>Підпис (до 22 символів)</label>
+                <input class="input" maxlength="22" [(ngModel)]="newLabel" />
+              </div>
+            </div>
+
+            @if (error()) {
+              <p style="color: var(--color-accent-2-700); font-size: 13px;">{{ error() }}</p>
+            }
+
+            <div class="dialog-actions">
+              <button class="btn btn-secondary" (click)="closeModal()">Готово</button>
+              <button class="btn btn-primary" [disabled]="!newLabel" (click)="addDate()">Додати дату</button>
+            </div>
+          </div>
+        </div>
       }
 
       <button
@@ -76,9 +110,24 @@ export class StyleDatesComponent implements OnInit {
   readonly order = signal<OrderDto | null>(null);
   readonly loading = signal(false);
   readonly error = signal<string | null>(null);
+  readonly selectedMonth = signal<number | null>(null);
+
+  readonly months = [
+    { number: 1, name: 'Січень' },
+    { number: 2, name: 'Лютий' },
+    { number: 3, name: 'Березень' },
+    { number: 4, name: 'Квітень' },
+    { number: 5, name: 'Травень' },
+    { number: 6, name: 'Червень' },
+    { number: 7, name: 'Липень' },
+    { number: 8, name: 'Серпень' },
+    { number: 9, name: 'Вересень' },
+    { number: 10, name: 'Жовтень' },
+    { number: 11, name: 'Листопад' },
+    { number: 12, name: 'Грудень' },
+  ];
 
   newDay = 1;
-  newMonth = 1;
   newLabel = '';
 
   private readonly orderId: string;
@@ -104,10 +153,31 @@ export class StyleDatesComponent implements OnInit {
     this.orders.selectStyle(this.orderId, cat.id).subscribe((o) => this.order.set(o));
   }
 
+  datesForMonth(month: number) {
+    return (this.order()?.personalDates ?? []).filter((d) => d.month === month);
+  }
+
+  monthName(month: number): string {
+    return this.months.find((m) => m.number === month)?.name ?? '';
+  }
+
+  openMonth(month: number): void {
+    this.selectedMonth.set(month);
+    this.newDay = 1;
+    this.newLabel = '';
+    this.error.set(null);
+  }
+
+  closeModal(): void {
+    this.selectedMonth.set(null);
+  }
+
   addDate(): void {
+    const month = this.selectedMonth();
+    if (!month) return;
     const label = this.newLabel.trim();
     if (!label) return;
-    this.orders.addDate(this.orderId, this.newDay, this.newMonth, label).subscribe({
+    this.orders.addDate(this.orderId, this.newDay, month, label).subscribe({
       next: (o) => {
         this.order.set(o);
         this.newLabel = '';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -204,3 +204,17 @@ textarea.input { min-height: 90px; resize: vertical; }
 .sheet-thumb.ready { border-style: solid; }
 .sheet-thumb.failed { border-style: solid; border-color: var(--color-accent-2); }
 .money { font-variant-numeric: tabular-nums; }
+
+.month-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: var(--space-2); }
+@media (max-width: 640px) { .month-grid { grid-template-columns: repeat(2, 1fr); } }
+.month-tile {
+  display: flex; flex-direction: column; gap: 6px; min-height: 92px;
+  padding: var(--space-2); text-align: left; cursor: pointer;
+  border: 1px solid var(--color-divider); border-radius: var(--radius-md); background: var(--color-surface);
+}
+.month-tile:hover { border-color: var(--color-accent); }
+.month-tile.has-dates { border-color: var(--color-accent); background: var(--color-accent-100); }
+.month-tile-name { font-family: var(--font-heading); font-weight: var(--font-heading-weight); font-size: 14px; }
+.month-tile-dates { display: flex; flex-direction: column; gap: 2px; }
+.month-tile-date { font-size: 11px; color: var(--color-accent-700); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.month-tile-empty { font-size: 12px; color: color-mix(in srgb, var(--color-text) 45%, transparent); }


### PR DESCRIPTION
## Summary
- Replaces the flat personal-dates list + free-typed day/month/label form on the style/dates step with a full 12-month grid (6x2 desktop, 2x6 mobile).
- Clicking a month tile opens a modal scoped to that month to view/remove existing dates and add a new one (day + label only — month is implied by the tile).

## Test plan
- [ ] Open an order's style/dates step, confirm the grid renders 6 wide on desktop and 2 wide on mobile widths
- [ ] Click a month, add a date, confirm it shows on the tile and in the modal list
- [ ] Remove a date from the modal, confirm it disappears from the tile