### PR TITLE
feat: email confirmation, real AI image generation, calendar date picker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@ frontend/node_modules/
 frontend/dist/
 frontend/.angular/
 
+# Local secrets
+.env
+
 # Editors / OS
 .vs/
 .vscode/

--- a/backend/src/Calendary.Api/Controllers/AuthController.cs
+++ b/backend/src/Calendary.Api/Controllers/AuthController.cs
@@ -48,7 +48,10 @@ public class AuthController(
                 user.Email!,
                 "Ласкаво просимо до Calendary",
                 $"<p>Привіт, {System.Net.WebUtility.HtmlEncode(user.DisplayName)}!</p>" +
-                "<p>Дякуємо за реєстрацію в Calendary. Можете одразу починати збирати свій календар.</p>");
+                "<p>Дякуємо за реєстрацію в Calendary. Можете одразу починати збирати свій календар.</p>" +
+                $"<p>Щоб підтвердити пошту, введіть цей код у застосунку: " +
+                $"<strong style=\"font-size:20px;letter-spacing:4px;\">{user.EmailConfirmationCode}</strong></p>" +
+                "<p>Код дійсний 30 хвилин.</p>");
         }
         catch (Exception ex)
         {
@@ -98,5 +101,73 @@ public class AuthController(
         var userId = User.GetUserId();
         var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId);
         return user is null ? Unauthorized() : Ok(user.ToDto());
+    }
+
+    [HttpPost("confirm-email")]
+    [Authorize]
+    public async Task<ActionResult<UserDto>> ConfirmEmail(ConfirmEmailRequest request)
+    {
+        var userId = User.GetUserId();
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+        if (user.EmailConfirmed)
+        {
+            return Ok(user.ToDto());
+        }
+
+        var code = request.Code?.Trim() ?? string.Empty;
+        if (user.EmailConfirmationCode is null
+            || user.EmailConfirmationCodeExpiresAtUtc is null
+            || user.EmailConfirmationCodeExpiresAtUtc < DateTime.UtcNow
+            || !string.Equals(user.EmailConfirmationCode, code, StringComparison.Ordinal))
+        {
+            return BadRequest("Невірний або прострочений код.");
+        }
+
+        user.EmailConfirmed = true;
+        user.EmailConfirmationCode = null;
+        user.EmailConfirmationCodeExpiresAtUtc = null;
+        await db.SaveChangesAsync();
+
+        return Ok(user.ToDto());
+    }
+
+    [HttpPost("resend-confirmation")]
+    [Authorize]
+    public async Task<IActionResult> ResendConfirmation()
+    {
+        var userId = User.GetUserId();
+        var user = await db.Users.FirstOrDefaultAsync(u => u.Id == userId);
+        if (user is null)
+        {
+            return Unauthorized();
+        }
+        if (user.EmailConfirmed)
+        {
+            return Ok();
+        }
+
+        user.EmailConfirmationCode = EmailConfirmationCodeGenerator.Generate();
+        user.EmailConfirmationCodeExpiresAtUtc = DateTime.UtcNow.Add(EmailConfirmationCodeGenerator.Lifetime);
+        await db.SaveChangesAsync();
+
+        try
+        {
+            await email.SendAsync(
+                user.Email!,
+                "Код підтвердження Calendary",
+                "<p>Ваш код підтвердження пошти:</p>" +
+                $"<p><strong style=\"font-size:20px;letter-spacing:4px;\">{user.EmailConfirmationCode}</strong></p>" +
+                "<p>Код дійсний 30 хвилин.</p>");
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Failed to send confirmation email to {Email}", user.Email);
+        }
+
+        return Ok();
     }
 }

--- a/backend/src/Calendary.Api/Dtos/DtoMapping.cs
+++ b/backend/src/Calendary.Api/Dtos/DtoMapping.cs
@@ -4,7 +4,7 @@ namespace Calendary.Api.Dtos;
 
 public static class DtoMapping
 {
-    public static UserDto ToDto(this User u) => new(u.Id, u.DisplayName, u.Email);
+    public static UserDto ToDto(this User u) => new(u.Id, u.DisplayName, u.Email, u.EmailConfirmed);
 
     public static StyleCategoryDto ToDto(this StyleCategory c) => new(c.Id, c.Code, c.Name, c.Description, c.SortOrder);
 

--- a/backend/src/Calendary.Api/Dtos/Dtos.cs
+++ b/backend/src/Calendary.Api/Dtos/Dtos.cs
@@ -3,7 +3,8 @@ namespace Calendary.Api.Dtos;
 public record RegisterRequest(string Email, string Password, string? DisplayName);
 public record LoginRequest(string Email, string Password);
 public record GoogleAuthRequest(string IdToken);
-public record UserDto(Guid Id, string? DisplayName, string? Email);
+public record ConfirmEmailRequest(string Code);
+public record UserDto(Guid Id, string? DisplayName, string? Email, bool EmailConfirmed);
 public record AuthResponse(string BearerToken, UserDto User);
 
 public record StyleCategoryDto(Guid Id, string Code, string Name, string Description, int SortOrder);

--- a/backend/src/Calendary.Api/Program.cs
+++ b/backend/src/Calendary.Api/Program.cs
@@ -1,3 +1,4 @@
+using Calendary.AI;
 using Calendary.Api.Auth;
 using Calendary.Domain.Abstractions;
 using Calendary.Infrastructure.Data;
@@ -13,7 +14,8 @@ var connectionString = builder.Configuration.GetConnectionString("Default")
 
 builder.Services.AddDbContext<AppDbContext>(options => options.UseSqlServer(connectionString));
 
-builder.Services.AddScoped<IImageGenerationService, MockImageGenerationService>();
+builder.Services.AddScoped<IImageGenerationService, AiImageGenerationService>();
+builder.Services.AddCalendaryAi(builder.Configuration);
 builder.Services.AddScoped<IPaymentService, MockPaymentService>();
 builder.Services.AddSingleton<INovaPoshtaService, MockNovaPoshtaService>();
 builder.Services.AddScoped<ISessionTokenService, SessionTokenService>();
@@ -23,7 +25,6 @@ builder.Services.Configure<GoogleOptions>(builder.Configuration.GetSection(Googl
 builder.Services.AddHttpClient<IEmailService, ResendEmailService>();
 builder.Services.Configure<ResendOptions>(builder.Configuration.GetSection(ResendOptions.SectionName));
 
-builder.Services.AddHostedService<GenerationBackgroundService>();
 builder.Services.AddHostedService<FulfillmentBackgroundService>();
 
 builder.Services.AddAuthentication(BearerTokenAuth.Scheme)

--- a/backend/src/Calendary.Domain/Entities/EmailConfirmationCodeGenerator.cs
+++ b/backend/src/Calendary.Domain/Entities/EmailConfirmationCodeGenerator.cs
@@ -1,0 +1,8 @@
+namespace Calendary.Domain.Entities;
+
+public static class EmailConfirmationCodeGenerator
+{
+    public static readonly TimeSpan Lifetime = TimeSpan.FromMinutes(30);
+
+    public static string Generate() => Random.Shared.Next(0, 1_000_000).ToString("D6");
+}

--- a/backend/src/Calendary.Domain/Entities/User.cs
+++ b/backend/src/Calendary.Domain/Entities/User.cs
@@ -11,6 +11,10 @@ public class User
     public AuthProvider AuthProvider { get; set; }
     public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
 
+    public bool EmailConfirmed { get; set; }
+    public string? EmailConfirmationCode { get; set; }
+    public DateTime? EmailConfirmationCodeExpiresAtUtc { get; set; }
+
     public ICollection<Order> Orders { get; set; } = new List<Order>();
     public ICollection<UserSession> Sessions { get; set; } = new List<UserSession>();
 }

--- a/backend/src/Calendary.Infrastructure/Migrations/20260824160325_AddEmailConfirmation.Designer.cs
+++ b/backend/src/Calendary.Infrastructure/Migrations/20260824160325_AddEmailConfirmation.Designer.cs
@@ -4,6 +4,7 @@ using Calendary.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Calendary.Infrastructure.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260824160325_AddEmailConfirmation")]
+    partial class AddEmailConfirmation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/backend/src/Calendary.Infrastructure/Migrations/20260824160325_AddEmailConfirmation.cs
+++ b/backend/src/Calendary.Infrastructure/Migrations/20260824160325_AddEmailConfirmation.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Calendary.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddEmailConfirmation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailConfirmationCode",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "EmailConfirmationCodeExpiresAtUtc",
+                table: "Users",
+                type: "datetime2",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "EmailConfirmed",
+                table: "Users",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailConfirmationCode",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "EmailConfirmationCodeExpiresAtUtc",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "EmailConfirmed",
+                table: "Users");
+        }
+    }
+}

--- a/backend/src/Calendary.Infrastructure/Services/GoogleAuthService.cs
+++ b/backend/src/Calendary.Infrastructure/Services/GoogleAuthService.cs
@@ -32,6 +32,15 @@ public class GoogleAuthService(AppDbContext db, IOptions<GoogleOptions> options)
         {
             // Matching by verified email — signing in with Google on an email that already has a
             // password account just logs into that same account rather than creating a duplicate.
+            // Google already verified ownership of this address, so it settles any pending
+            // confirmation from the password-registration flow too.
+            if (!user.EmailConfirmed)
+            {
+                user.EmailConfirmed = true;
+                user.EmailConfirmationCode = null;
+                user.EmailConfirmationCodeExpiresAtUtc = null;
+                await db.SaveChangesAsync(ct);
+            }
             return user;
         }
 
@@ -39,7 +48,8 @@ public class GoogleAuthService(AppDbContext db, IOptions<GoogleOptions> options)
         {
             Email = email,
             DisplayName = string.IsNullOrWhiteSpace(payload.Name) ? email.Split('@')[0] : payload.Name,
-            AuthProvider = AuthProvider.Google
+            AuthProvider = AuthProvider.Google,
+            EmailConfirmed = true
         };
         db.Users.Add(user);
         await db.SaveChangesAsync(ct);

--- a/backend/src/Calendary.Infrastructure/Services/PasswordAuthService.cs
+++ b/backend/src/Calendary.Infrastructure/Services/PasswordAuthService.cs
@@ -23,7 +23,9 @@ public class PasswordAuthService(AppDbContext db) : IPasswordAuthService
         {
             Email = normalizedEmail,
             DisplayName = string.IsNullOrWhiteSpace(displayName) ? normalizedEmail.Split('@')[0] : displayName.Trim(),
-            AuthProvider = AuthProvider.Password
+            AuthProvider = AuthProvider.Password,
+            EmailConfirmationCode = EmailConfirmationCodeGenerator.Generate(),
+            EmailConfirmationCodeExpiresAtUtc = DateTime.UtcNow.Add(EmailConfirmationCodeGenerator.Lifetime),
         };
         user.PasswordHash = _hasher.HashPassword(user, password);
 

--- a/backend/src/Calendary.Infrastructure/Services/ResendEmailService.cs
+++ b/backend/src/Calendary.Infrastructure/Services/ResendEmailService.cs
@@ -17,7 +17,10 @@ public class ResendEmailService(HttpClient httpClient, IOptions<ResendOptions> o
     {
         if (string.IsNullOrWhiteSpace(_options.ApiKey))
         {
-            logger.LogInformation("Resend:ApiKey not configured — skipping email to {To}: {Subject}", to, subject);
+            // No real send in local dev — log the full body so e.g. a confirmation code is still
+            // visible to whoever is testing, without needing a real Resend API key.
+            logger.LogInformation(
+                "Resend:ApiKey not configured — skipping email to {To}: {Subject}\n{Html}", to, subject, html);
             return;
         }
 

--- a/dev.ps1
+++ b/dev.ps1
@@ -1,0 +1,57 @@
+<#
+.SYNOPSIS
+Runs Calendary locally for development.
+
+.DESCRIPTION
+Starts mssql + backend in Docker (EF Core migrations apply automatically on backend
+startup) and runs the frontend via `ng serve` on :4200 instead of the Docker frontend
+image, so it hot-reloads on save. The frontend's own :4200 docker container is stopped
+first to free the port — dev-mode CORS (`Cors__AllowedOrigins__0` in docker-compose.yml)
+and the Google OAuth client are both configured for http://localhost:4200, so the
+frontend has to run on that exact port.
+
+.PARAMETER SkipBuild
+Skip rebuilding the backend image (faster restart when only frontend files changed).
+#>
+
+param(
+    [switch]$SkipBuild
+)
+
+$ErrorActionPreference = 'Stop'
+$root = Split-Path -Parent $MyInvocation.MyCommand.Path
+Set-Location $root
+
+Write-Host "Stopping docker frontend container (frees :4200 for ng serve)..." -ForegroundColor Cyan
+docker compose stop frontend 2>$null | Out-Null
+
+if ($SkipBuild) {
+    Write-Host "Starting mssql + backend (no rebuild)..." -ForegroundColor Cyan
+    docker compose up -d mssql backend
+} else {
+    Write-Host "Building and starting mssql + backend..." -ForegroundColor Cyan
+    docker compose up -d --build mssql backend
+}
+
+Write-Host "Waiting for backend on http://localhost:5080 ..." -ForegroundColor Cyan
+$deadline = (Get-Date).AddSeconds(90)
+$ready = $false
+while ((Get-Date) -lt $deadline) {
+    try {
+        $resp = Invoke-WebRequest -Uri 'http://localhost:5080/swagger/index.html' -UseBasicParsing -TimeoutSec 2
+        if ($resp.StatusCode -eq 200) { $ready = $true; break }
+    } catch {}
+    Start-Sleep -Seconds 2
+}
+if (-not $ready) {
+    Write-Warning "Backend didn't respond within 90s — check 'docker compose logs backend'. Continuing anyway."
+}
+
+Set-Location (Join-Path $root 'frontend')
+if (-not (Test-Path node_modules)) {
+    Write-Host "Installing frontend dependencies..." -ForegroundColor Cyan
+    npm install
+}
+
+Write-Host "Starting frontend on http://localhost:4200 (Ctrl+C to stop)..." -ForegroundColor Cyan
+npx ng serve --port 4200 --proxy-config proxy.conf.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       ConnectionStrings__Default: "Server=mssql,1433;Database=Calendary;User Id=sa;Password=Your_password123;TrustServerCertificate=True"
       Cors__AllowedOrigins__0: "http://localhost:4200"
       ASPNETCORE_ENVIRONMENT: "Development"
+      Resend__ApiKey: "${RESEND_API_KEY:-}"
+      AI__OpenAI__ApiKey: "${OPENAI_API_KEY:-}"
+      AI__Gemini__ApiKey: "${GEMINI_API_KEY:-}"
     ports:
       - "5080:8080"
     depends_on:

--- a/frontend/src/app/app.component.ts
+++ b/frontend/src/app/app.component.ts
@@ -1,10 +1,14 @@
 import { Component } from '@angular/core';
 import { RouterOutlet } from '@angular/router';
+import { EmailConfirmBannerComponent } from './email-confirm-banner.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet],
-  template: `<router-outlet />`,
+  imports: [RouterOutlet, EmailConfirmBannerComponent],
+  template: `
+    <app-email-confirm-banner />
+    <router-outlet />
+  `,
 })
 export class AppComponent {}

--- a/frontend/src/app/core/auth.service.ts
+++ b/frontend/src/app/core/auth.service.ts
@@ -17,6 +17,8 @@ export class AuthService {
 
   readonly user = computed(() => this.session()?.user ?? null);
   readonly isAuthenticated = computed(() => this.session() !== null);
+  readonly needsEmailConfirmation = computed(() => this.user()?.emailConfirmed === false);
+  readonly confirmModalOpen = signal(false);
 
   constructor(private readonly http: HttpClient) {}
 
@@ -54,6 +56,32 @@ export class AuthService {
   logout(): void {
     this.session.set(null);
     localStorage.removeItem(STORAGE_KEY);
+  }
+
+  openConfirmModal(): void {
+    this.confirmModalOpen.set(true);
+  }
+
+  closeConfirmModal(): void {
+    this.confirmModalOpen.set(false);
+  }
+
+  confirmEmail(code: string): Observable<UserDto> {
+    return this.http
+      .post<UserDto>(`${environment.apiBaseUrl}/api/auth/confirm-email`, { code })
+      .pipe(tap((user) => this.updateUser(user)));
+  }
+
+  resendConfirmation(): Observable<void> {
+    return this.http.post<void>(`${environment.apiBaseUrl}/api/auth/resend-confirmation`, {});
+  }
+
+  private updateUser(user: UserDto): void {
+    const current = this.session();
+    if (!current) return;
+    const stored: StoredSession = { ...current, user };
+    this.session.set(stored);
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(stored));
   }
 
   private storeSession(res: { bearerToken: string; user: UserDto }): void {

--- a/frontend/src/app/core/models.ts
+++ b/frontend/src/app/core/models.ts
@@ -2,6 +2,7 @@ export interface UserDto {
   id: string;
   displayName: string | null;
   email: string | null;
+  emailConfirmed: boolean;
 }
 
 export interface StyleCategoryDto {

--- a/frontend/src/app/email-confirm-banner.component.ts
+++ b/frontend/src/app/email-confirm-banner.component.ts
@@ -1,0 +1,111 @@
+import { Component, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { AuthService } from './core/auth.service';
+
+@Component({
+  selector: 'app-email-confirm-banner',
+  standalone: true,
+  imports: [FormsModule],
+  template: `
+    @if (auth.needsEmailConfirmation()) {
+      <div class="banner-top">
+        <span>Підтвердіть пошту {{ auth.user()?.email }}, щоб не втратити доступ до замовлення.</span>
+        <button class="btn btn-ghost" (click)="open()">Підтвердити</button>
+      </div>
+    }
+
+    @if (auth.confirmModalOpen()) {
+      <div class="dialog-backdrop" (click)="close()">
+        <div class="dialog" (click)="$event.stopPropagation()">
+          <div class="dialog-title">Підтвердження пошти</div>
+          <p class="dialog-body">
+            Ми надіслали 6-значний код на {{ auth.user()?.email }}. Введіть його нижче.
+          </p>
+
+          <div class="field">
+            <label>Код підтвердження</label>
+            <input
+              class="input"
+              style="letter-spacing: 6px; font-size: 18px; text-align: center;"
+              maxlength="6"
+              inputmode="numeric"
+              [(ngModel)]="code"
+              (keyup.enter)="submit()"
+            />
+          </div>
+
+          @if (error()) {
+            <p style="color: var(--color-accent-2-700); font-size: 13px;">{{ error() }}</p>
+          }
+          @if (resendMessage()) {
+            <p class="text-muted" style="font-size: 12px;">{{ resendMessage() }}</p>
+          }
+
+          <div class="dialog-actions" style="justify-content: space-between;">
+            <button class="btn btn-ghost" [disabled]="resendLoading()" (click)="resend()">
+              Надіслати код ще раз
+            </button>
+            <div style="display: flex; gap: var(--space-2);">
+              <button class="btn btn-secondary" (click)="close()">Скасувати</button>
+              <button class="btn btn-primary" [disabled]="code.length !== 6 || loading()" (click)="submit()">
+                Підтвердити
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    }
+  `,
+})
+export class EmailConfirmBannerComponent {
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly resendLoading = signal(false);
+  readonly resendMessage = signal<string | null>(null);
+
+  code = '';
+
+  constructor(readonly auth: AuthService) {}
+
+  open(): void {
+    this.code = '';
+    this.error.set(null);
+    this.resendMessage.set(null);
+    this.auth.openConfirmModal();
+  }
+
+  close(): void {
+    this.auth.closeConfirmModal();
+  }
+
+  submit(): void {
+    if (this.code.length !== 6) return;
+    this.loading.set(true);
+    this.error.set(null);
+    this.auth.confirmEmail(this.code).subscribe({
+      next: () => {
+        this.loading.set(false);
+        this.close();
+      },
+      error: () => {
+        this.loading.set(false);
+        this.error.set('Невірний або прострочений код.');
+      },
+    });
+  }
+
+  resend(): void {
+    this.resendLoading.set(true);
+    this.resendMessage.set(null);
+    this.auth.resendConfirmation().subscribe({
+      next: () => {
+        this.resendLoading.set(false);
+        this.resendMessage.set('Код надіслано ще раз.');
+      },
+      error: () => {
+        this.resendLoading.set(false);
+        this.resendMessage.set('Не вдалося надіслати код. Спробуйте пізніше.');
+      },
+    });
+  }
+}

--- a/frontend/src/app/pages/checkout/checkout.component.ts
+++ b/frontend/src/app/pages/checkout/checkout.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit, signal } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { OrderService } from '../../core/order.service';
+import { AuthService } from '../../core/auth.service';
 import { NovaPoshtaWarehouseDto, OrderDto } from '../../core/models';
 
 @Component({
@@ -68,6 +69,13 @@ import { NovaPoshtaWarehouseDto, OrderDto } from '../../core/models';
           <p style="color: var(--color-accent-2-700); font-size: 13px; margin-top: var(--space-2);">{{ error() }}</p>
         }
 
+        @if (auth.needsEmailConfirmation()) {
+          <p class="text-muted" style="font-size: 12px; margin-top: var(--space-2);">
+            Пошту не підтверджено — ви можете не отримати сповіщення про статус замовлення.
+            <button class="btn btn-ghost" style="padding: 0;" (click)="auth.openConfirmModal()">Підтвердити</button>
+          </p>
+        }
+
         <button
           class="btn btn-primary btn-block"
           style="min-height: 50px; font-size: 15px;"
@@ -109,6 +117,7 @@ export class CheckoutComponent implements OnInit {
     private readonly route: ActivatedRoute,
     private readonly router: Router,
     private readonly orders: OrderService,
+    readonly auth: AuthService,
   ) {
     this.orderId = this.route.snapshot.paramMap.get('orderId')!;
   }

--- a/frontend/src/app/pages/style-dates/style-dates.component.ts
+++ b/frontend/src/app/pages/style-dates/style-dates.component.ts
@@ -39,15 +39,21 @@ import { OrderDto, StyleCategoryDto } from '../../core/models';
             (click)="openMonth(m.number)"
           >
             <div class="month-tile-name">{{ m.name }}</div>
-            @if (datesForMonth(m.number).length) {
-              <div class="month-tile-dates">
-                @for (date of datesForMonth(m.number); track date.id) {
-                  <span class="month-tile-date">{{ pad(date.day) }} · {{ date.label }}</span>
+            <div class="tile-calendar">
+              @for (day of calendarCells(m.number); track $index) {
+                @if (day === null) {
+                  <span class="tile-calendar-day empty"></span>
+                } @else {
+                  <span
+                    class="tile-calendar-day"
+                    [class.has-date]="hasDate(m.number, day)"
+                    [title]="labelForDay(m.number, day)"
+                  >
+                    {{ day }}
+                  </span>
                 }
-              </div>
-            } @else {
-              <div class="month-tile-empty">+ Додати</div>
-            }
+              }
+            </div>
           </button>
         }
       </div>
@@ -71,15 +77,30 @@ import { OrderDto, StyleCategoryDto } from '../../core/models';
               </div>
             }
 
-            <div style="display: flex; gap: 10px; align-items: flex-end; flex-wrap: wrap;">
-              <div class="field" style="width: 70px;">
-                <label>День</label>
-                <input class="input" type="number" min="1" max="31" [(ngModel)]="newDay" />
-              </div>
-              <div class="field" style="flex: 1; min-width: 180px;">
-                <label>Підпис (до 22 символів)</label>
-                <input class="input" maxlength="22" [(ngModel)]="newLabel" />
-              </div>
+            <div class="calendar-grid">
+              @for (w of weekdays; track w) {
+                <div class="calendar-weekday">{{ w }}</div>
+              }
+              @for (day of calendarCells(month); track $index) {
+                @if (day === null) {
+                  <div class="calendar-day empty"></div>
+                } @else {
+                  <button
+                    type="button"
+                    class="calendar-day"
+                    [class.has-date]="hasDate(month, day)"
+                    [class.selected]="newDay === day"
+                    (click)="selectDay(day)"
+                  >
+                    {{ day }}
+                  </button>
+                }
+              }
+            </div>
+
+            <div class="field">
+              <label>Підпис (до 22 символів)</label>
+              <input class="input" maxlength="22" [(ngModel)]="newLabel" />
             </div>
 
             @if (error()) {
@@ -88,7 +109,7 @@ import { OrderDto, StyleCategoryDto } from '../../core/models';
 
             <div class="dialog-actions">
               <button class="btn btn-secondary" (click)="closeModal()">Готово</button>
-              <button class="btn btn-primary" [disabled]="!newLabel" (click)="addDate()">Додати дату</button>
+              <button class="btn btn-primary" [disabled]="!newLabel || !newDay" (click)="addDate()">Додати дату</button>
             </div>
           </div>
         </div>
@@ -127,7 +148,10 @@ export class StyleDatesComponent implements OnInit {
     { number: 12, name: 'Грудень' },
   ];
 
-  newDay = 1;
+  readonly weekdays = ['Пн', 'Вт', 'Ср', 'Чт', 'Пт', 'Сб', 'Нд'];
+  private readonly calendarYear = new Date().getFullYear() + 1;
+
+  newDay: number | null = null;
   newLabel = '';
 
   private readonly orderId: string;
@@ -161,9 +185,33 @@ export class StyleDatesComponent implements OnInit {
     return this.months.find((m) => m.number === month)?.name ?? '';
   }
 
+  calendarCells(month: number): (number | null)[] {
+    const firstWeekday = (new Date(this.calendarYear, month - 1, 1).getDay() + 6) % 7;
+    const daysInMonth = new Date(this.calendarYear, month, 0).getDate();
+    const cells: (number | null)[] = new Array(firstWeekday).fill(null);
+    for (let day = 1; day <= daysInMonth; day++) cells.push(day);
+    while (cells.length < 42) cells.push(null);
+    return cells;
+  }
+
+  hasDate(month: number, day: number): boolean {
+    return this.datesForMonth(month).some((d) => d.day === day);
+  }
+
+  labelForDay(month: number, day: number): string {
+    return this.datesForMonth(month)
+      .filter((d) => d.day === day)
+      .map((d) => d.label)
+      .join(', ');
+  }
+
+  selectDay(day: number): void {
+    this.newDay = day;
+  }
+
   openMonth(month: number): void {
     this.selectedMonth.set(month);
-    this.newDay = 1;
+    this.newDay = null;
     this.newLabel = '';
     this.error.set(null);
   }
@@ -174,10 +222,11 @@ export class StyleDatesComponent implements OnInit {
 
   addDate(): void {
     const month = this.selectedMonth();
-    if (!month) return;
+    const day = this.newDay;
+    if (!month || !day) return;
     const label = this.newLabel.trim();
     if (!label) return;
-    this.orders.addDate(this.orderId, this.newDay, month, label).subscribe({
+    this.orders.addDate(this.orderId, day, month, label).subscribe({
       next: (o) => {
         this.order.set(o);
         this.newLabel = '';

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -205,16 +205,39 @@ textarea.input { min-height: 90px; resize: vertical; }
 .sheet-thumb.failed { border-style: solid; border-color: var(--color-accent-2); }
 .money { font-variant-numeric: tabular-nums; }
 
-.month-grid { display: grid; grid-template-columns: repeat(6, 1fr); gap: var(--space-2); }
+.month-grid { display: grid; grid-template-columns: repeat(6, 1fr); grid-auto-rows: 1fr; gap: var(--space-2); }
 @media (max-width: 640px) { .month-grid { grid-template-columns: repeat(2, 1fr); } }
 .month-tile {
-  display: flex; flex-direction: column; gap: 6px; min-height: 92px;
+  display: flex; flex-direction: column; gap: 6px;
   padding: var(--space-2); text-align: left; cursor: pointer;
   border: 1px solid var(--color-divider); border-radius: var(--radius-md); background: var(--color-surface);
 }
 .month-tile:hover { border-color: var(--color-accent); }
 .month-tile.has-dates { border-color: var(--color-accent); background: var(--color-accent-100); }
 .month-tile-name { font-family: var(--font-heading); font-weight: var(--font-heading-weight); font-size: 14px; }
-.month-tile-dates { display: flex; flex-direction: column; gap: 2px; }
-.month-tile-date { font-size: 11px; color: var(--color-accent-700); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.month-tile-empty { font-size: 12px; color: color-mix(in srgb, var(--color-text) 45%, transparent); }
+
+.tile-calendar { display: grid; grid-template-columns: repeat(7, 1fr); gap: 2px; }
+.tile-calendar-day {
+  aspect-ratio: 1; display: flex; align-items: center; justify-content: center;
+  font-size: 9px; border-radius: 1px; color: color-mix(in srgb, var(--color-text) 60%, transparent);
+}
+.tile-calendar-day.empty { visibility: hidden; }
+.tile-calendar-day.has-date { background: var(--color-accent); color: var(--color-bg); font-weight: 700; }
+
+.calendar-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
+.calendar-weekday { font-size: 11px; text-align: center; color: color-mix(in srgb, var(--color-text) 55%, transparent); padding-bottom: 4px; }
+.calendar-day {
+  aspect-ratio: 1; display: flex; align-items: center; justify-content: center;
+  font: inherit; font-size: 13px; color: var(--color-text); cursor: pointer;
+  background: transparent; border: 1px solid transparent; border-radius: var(--radius-sm);
+}
+.calendar-day:hover:not(.empty) { border-color: var(--color-accent); }
+.calendar-day.empty { visibility: hidden; cursor: default; }
+.calendar-day.has-date { background: var(--color-accent-100); color: var(--color-accent-800); font-weight: 600; }
+.calendar-day.selected { background: var(--color-accent); color: var(--color-bg); }
+
+.banner-top {
+  display: flex; align-items: center; justify-content: center; gap: var(--space-3);
+  padding: 10px var(--space-4); background: var(--color-accent-100); color: var(--color-accent-800);
+  font-size: 13px; text-align: center; flex-wrap: wrap;
+}


### PR DESCRIPTION
## Summary
- **Email confirmation**: registration generates a 6-digit code, sent via the existing Resend welcome email. New `POST /api/auth/confirm-email` and `POST /api/auth/resend-confirmation` endpoints. Google sign-in auto-confirms. Non-blocking top banner + modal on the frontend, plus a reminder on checkout — confirmation doesn't block ordering.
- **Real AI image generation**: switched `IImageGenerationService` to `AiImageGenerationService` (OpenAI-backed) and removed the now-conflicting `GenerationBackgroundService` mock timer, per the README's documented switch-over steps. Verified end-to-end against a real test order (all 13 sheets generated successfully via the OpenAI Images API).
- **Personal dates step**: month tiles now show a fixed-size mini calendar (Monday-first, Ukrainian weekday labels) instead of a free-typed day number; same calendar picker in the add-date modal.
- **dev.ps1**: local dev script — mssql+backend in Docker, frontend via `ng serve` on :4200 (matches CORS/Google OAuth origin, hot-reloads).
- Wires `RESEND_API_KEY` / `OPENAI_API_KEY` / `GEMINI_API_KEY` from a local gitignored `.env` into `docker-compose.yml`, mirroring the prod/staging pattern.

## Test plan
- [ ] Register a new account, confirm the welcome email includes a 6-digit code, confirm it via the banner modal
- [ ] Verify the checkout reminder shows for an unconfirmed account and disappears after confirming
- [ ] Run a test order through generation locally and confirm real images come back (not picsum placeholders)
- [ ] Open the personal-dates step, confirm the calendar view renders correctly on desktop and mobile
- [ ] Run `.\dev.ps1` on a clean checkout and confirm it comes up end-to-end