### PR TITLE
ci: thread AI provider keys into staging deploy

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -92,6 +92,10 @@ jobs:
             printf 'GOOGLE_CLIENT_SECRET=%s\n' "${{ secrets.GOOGLE_CLIENT_SECRET }}" >> .env.staging
             grep -v '^RESEND_API_KEY=' .env.staging > .env.staging.tmp || true; mv .env.staging.tmp .env.staging
             printf 'RESEND_API_KEY=%s\n' "${{ secrets.RESEND_API_KEY }}" >> .env.staging
+            grep -v '^AI_OPENAI_API_KEY=' .env.staging > .env.staging.tmp || true; mv .env.staging.tmp .env.staging
+            grep -v '^AI_GEMINI_API_KEY=' .env.staging > .env.staging.tmp || true; mv .env.staging.tmp .env.staging
+            printf 'AI_OPENAI_API_KEY=%s\n' "${{ secrets.AI_OPENAI_API_KEY }}" >> .env.staging
+            printf 'AI_GEMINI_API_KEY=%s\n' "${{ secrets.AI_GEMINI_API_KEY }}" >> .env.staging
 
             docker compose -p calendary-staging -f docker-compose.staging.yml --env-file .env.staging pull
             docker compose -p calendary-staging -f docker-compose.staging.yml --env-file .env.staging up -d --remove-orphans


### PR DESCRIPTION
## Summary
- Threads `AI_OPENAI_API_KEY` / `AI_GEMINI_API_KEY` (new GH secrets) into the droplet's `.env.staging` on every staging deploy, mirroring the existing `RESEND_API_KEY` pattern.
- Follow-up to #284, which switched staging to the real `AiImageGenerationService` with no mock fallback — without this, generation fails on every order since no key was ever threaded in.

## Test plan
- [ ] After merge/deploy, run a test order through generation on staging and confirm real images come back